### PR TITLE
Allow copying files from remote host(s) to local host

### DIFF
--- a/pssh/pssh_client.py
+++ b/pssh/pssh_client.py
@@ -871,11 +871,6 @@ future releases - use self.run_command instead", DeprecationWarning)
           created as long as permissions allow.
 
         .. note ::
-          Path separation is handled client side so it is possible to copy
-          to/from hosts with differing path separators, like from/to Linux
-          and Windows.
-
-        .. note ::
           File names will be de-duplicated by appending the hostname to the
           filepath.
 
@@ -892,4 +887,4 @@ future releases - use self.run_command instead", DeprecationWarning)
                                                 password=self.password,
                                                 port=self.port, pkey=self.pkey,
                                                 forward_ssh_agent=self.forward_ssh_agent)
-        return self.host_clients[host].copy_file_to_local(remote_file, local_file + '_' + host)
+        return self.host_clients[host].copy_file_to_local(remote_file, '_'.join([local_file, host]))

--- a/pssh/pssh_client.py
+++ b/pssh/pssh_client.py
@@ -845,18 +845,9 @@ future releases - use self.run_command instead", DeprecationWarning)
 
     def _copy_file(self, host, local_file, remote_file, recurse):
         """Make sftp client, copy file"""
-        if not host in self.host_clients or not self.host_clients[host]:
-            _user, _port, _password, _pkey = self._get_host_config_values(host)
-            self.host_clients[host] = SSHClient(
-                host, user=_user, password=_password, port=_port, pkey=_pkey,
-                forward_ssh_agent=self.forward_ssh_agent,
-                num_retries=self.num_retries,
-                timeout=self.timeout,
-                proxy_host=self.proxy_host,
-                proxy_port=self.proxy_port,
-                agent=self.agent,
-                channel_timeout=self.channel_timeout)
-        return self.host_clients[host].copy_file(local_file, remote_file, recurse=recurse)
+        self._make_ssh_client(host)
+        return self.host_clients[host].copy_file(local_file, remote_file,
+                                                 recurse=recurse)
 
     def copy_file_to_local(self, remote_file, local_file, recurse=False):
         """Copy remote file to local file in parallel
@@ -883,9 +874,19 @@ future releases - use self.run_command instead", DeprecationWarning)
 
     def _copy_file_to_local(self, host, remote_file, local_file, recurse):
         """Make sftp client, copy file to local"""
-        if not self.host_clients[host]:
-            self.host_clients[host] = SSHClient(host, user=self.user,
-                                                password=self.password,
-                                                port=self.port, pkey=self.pkey,
-                                                forward_ssh_agent=self.forward_ssh_agent)
-        return self.host_clients[host].copy_file_to_local(remote_file, '_'.join([local_file, host]), recurse=recurse)
+        self._make_ssh_client(host)
+        return self.host_clients[host].copy_file_to_local(
+                remote_file, '_'.join([local_file, host]), recurse=recurse)
+
+    def _make_ssh_client(self, host):
+        if not host in self.host_clients or not self.host_clients[host]:
+            _user, _port, _password, _pkey = self._get_host_config_values(host)
+            self.host_clients[host] = SSHClient(
+                host, user=_user, password=_password, port=_port, pkey=_pkey,
+                forward_ssh_agent=self.forward_ssh_agent,
+                num_retries=self.num_retries,
+                timeout=self.timeout,
+                proxy_host=self.proxy_host,
+                proxy_port=self.proxy_port,
+                agent=self.agent,
+                channel_timeout=self.channel_timeout)

--- a/pssh/pssh_client.py
+++ b/pssh/pssh_client.py
@@ -814,6 +814,8 @@ future releases - use self.run_command instead", DeprecationWarning)
         This function returns a list of greenlets which can be
         `join`ed on to wait for completion.
 
+        :mod:`gevent.joinall` function may be used to join on all greenlets.
+
         Use `.get` on each greenlet to raise any exceptions from them.
 
         Exceptions listed here are raised when `.get` is called on each
@@ -851,7 +853,17 @@ future releases - use self.run_command instead", DeprecationWarning)
 
     def copy_remote_file(self, remote_file, local_file, recurse=False,
                          suffix_separator='_'):
-        """Copy remote file to local file in parallel
+        """Copy remote file(s) in parallel
+
+        This function, like :mod:`ParallelSSHClient.copy_file`, returns a list
+        of greenlets which can be `join`ed on to wait for completion.
+
+        :mod:`gevent.joinall` function may be used to join on all greenlets.
+
+        Use `.get` on each greenlet to raise any exceptions from them.
+
+        Exceptions listed here are raised when `.get` is called on each
+        greenlet, not this function itself.
 
         :param remote_file: remote filepath to copy to local host
         :type remote_file: str
@@ -860,9 +872,9 @@ future releases - use self.run_command instead", DeprecationWarning)
         :param recurse: whether or not to recurse
         :type recurse: bool
         :param suffix_separator: (Optional) Separator string between \
-        filename and host, defaults to ``_``. Eg for a ``local_file`` value of \
-        ``my_file`` and default seaparator the resulting filename will be \
-        ``my_file_my_host`` for the file from host ``my_host``
+        filename and host, defaults to ``_``. For example, for a ``local_file`` \
+        value of ``my_file`` and default separator the resulting filename will \
+        be ``my_file_my_host`` for the file from host ``my_host``
         :type suffix_separator: str
         .. note ::
           Local directories in `local_file` that do not exist will be

--- a/pssh/pssh_client.py
+++ b/pssh/pssh_client.py
@@ -843,7 +843,7 @@ future releases - use self.run_command instead", DeprecationWarning)
                                 {'recurse' : recurse})
                 for host in self.hosts]
 
-    def _copy_file(self, host, local_file, remote_file, recurse=False):
+    def _copy_file(self, host, local_file, remote_file, recurse):
         """Make sftp client, copy file"""
         if not host in self.host_clients or not self.host_clients[host]:
             _user, _port, _password, _pkey = self._get_host_config_values(host)
@@ -856,16 +856,17 @@ future releases - use self.run_command instead", DeprecationWarning)
                 proxy_port=self.proxy_port,
                 agent=self.agent,
                 channel_timeout=self.channel_timeout)
-        return self.host_clients[host].copy_file(local_file, remote_file,
+        return self.host_clients[host].copy_file(local_file, remote_file, recurse=recurse)
 
-    def copy_file_to_local(self, remote_file, local_file):
+    def copy_file_to_local(self, remote_file, local_file, recurse=False):
         """Copy remote file to local file in parallel
 
         :param remote_file: remote filepath to copy to local host
         :type remote_file: str
         :param local_file: local filepath on local host to copy file to
         :type local_file: str
-
+        :param recurse: whether or not to recurse
+        :type recurse: bool
         .. note ::
           Local directories in `local_file` that do not exist will be
           created as long as permissions allow.
@@ -877,14 +878,14 @@ future releases - use self.run_command instead", DeprecationWarning)
         :rtype: List(:mod:`gevent.Greenlet`) of greenlets for remote copy \
         commands
         """
-        return [self.pool.spawn(self._copy_file_to_local, host, remote_file, local_file)
+        return [self.pool.spawn(self._copy_file_to_local, host, remote_file, local_file, recurse)
                 for host in self.hosts]
 
-    def _copy_file_to_local(self, host, remote_file, local_file):
+    def _copy_file_to_local(self, host, remote_file, local_file, recurse):
         """Make sftp client, copy file to local"""
         if not self.host_clients[host]:
             self.host_clients[host] = SSHClient(host, user=self.user,
                                                 password=self.password,
                                                 port=self.port, pkey=self.pkey,
                                                 forward_ssh_agent=self.forward_ssh_agent)
-        return self.host_clients[host].copy_file_to_local(remote_file, '_'.join([local_file, host]))
+        return self.host_clients[host].copy_file_to_local(remote_file, '_'.join([local_file, host]), recurse=recurse)

--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -360,13 +360,7 @@ class SSHClient(object):
             raise ValueError("Recurse must be true if local_file is a "
                              "directory.")
         sftp = self._make_sftp()
-        try:
-            destination = os.path.sep.join([_dir for _dir in remote_file.split(os.path.sep)
-                           if _dir][:-1])
-        except IndexError:
-            destination = ''
-        if remote_file.startswith(os.path.sep) or not destination:
-            destination = os.path.sep + destination
+        destination = self._parent_path_split(remote_file)
         if os.path.sep in remote_file:
             self.mkdir(sftp, destination)
         sftp.chdir()
@@ -415,15 +409,13 @@ class SSHClient(object):
         elif remote_dir_exists and not recurse:
             raise ValueError("Recurse must be true if local_file is a "
                              "directory.")
-        destination = [_dir for _dir in local_file.split(os.path.sep)
-                       if _dir][:-1][0]
-        if local_file.startswith(os.path.sep):
-            destination = os.path.sep + destination
+        destination = self._parent_path_split(local_file)
         if not os.path.exists(destination):
             try:
                 os.makedirs(destination)
-            except OSError:
+            except OSError, exception:
                 logger.error("Unable to create local directory structure.")
+                raise exception
         try:
             sftp.get(remote_file, local_file)
         except Exception, error:
@@ -432,3 +424,11 @@ class SSHClient(object):
         else:
             logger.info("Copied local file %s from remote destination %s:%s",
                         local_file, self.host, remote_file)
+
+    @staticmethod
+    def _parent_path_split(file_path):
+        destination = [_dir for _dir in file_path.split(os.path.sep)
+                       if _dir][:-1][0]
+        if file_path.startswith(os.path.sep):
+            destination = os.path.sep + destination
+        return destination

--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -407,15 +407,15 @@ class SSHClient(object):
         if remote_dir_exists and recurse:
             return self._copy_dir_to_local(remote_file, local_file)
         elif remote_dir_exists and not recurse:
-            raise ValueError("Recurse must be true if local_file is a "
+            raise ValueError("Recurse must be true if remote_file is a "
                              "directory.")
         destination = self._parent_path_split(local_file)
         if not os.path.exists(destination):
             try:
                 os.makedirs(destination)
-            except OSError, exception:
+            except OSError:
                 logger.error("Unable to create local directory structure.")
-                raise exception
+                raise
         try:
             sftp.get(remote_file, local_file)
         except Exception, error:

--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -400,6 +400,9 @@ class SSHClient(object):
         :type local_file: str
         :param recurse: Whether or not to recursively copy directories.
         :type recurse: bool
+
+        :raises: :mod:'ValueError' when a directory is supplied to remote_file \
+        and recurse is not set
         """
         sftp = self._make_sftp()
         try:
@@ -409,6 +412,9 @@ class SSHClient(object):
             remote_dir_exists = False
         if remote_dir_exists and recurse:
             return self._copy_dir_to_local(remote_file, local_file)
+        elif remote_dir_exists and not recurse:
+            raise ValueError("Recurse must be true if local_file is a "
+                             "directory.")
         destination = [_dir for _dir in local_file.split(os.path.sep)
                        if _dir][:-1][0]
         if local_file.startswith(os.path.sep):

--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -397,38 +397,46 @@ class SSHClient(object):
         :param recurse: Whether or not to recursively copy directories.
         :type recurse: bool
 
-        :raises: :mod:'ValueError' when a directory is supplied to remote_file \
+        :raises: :mod:`ValueError` when a directory is supplied to remote_file \
         and recurse is not set
+        :raises: :mod:`OSError` on OS errors creating directories or file
+        :raises: :mod:`IOError` on IO errors creating directories or file
         """
         sftp = self._make_sftp()
         try:
             sftp.listdir(remote_file)
-            remote_dir_exists = True
-        except IOError or OSError:
+        except (OSError, IOError):
             remote_dir_exists = False
+        else:
+            remote_dir_exists = True
         if remote_dir_exists and recurse:
             return self._copy_dir_to_local(remote_file, local_file)
         elif remote_dir_exists and not recurse:
             raise ValueError("Recurse must be true if remote_file is a "
                              "directory.")
         destination = self._parent_path_split(local_file)
-        if not os.path.exists(destination):
-            try:
-                os.makedirs(destination)
-            except OSError:
-                logger.error("Unable to create local directory structure.")
-                raise
+        self._make_local_dir(destination)
         try:
+            import ipdb; ipdb.set_trace()
             sftp.get(remote_file, local_file)
         except Exception, error:
             logger.error("Error occured copying file %s from remote destination %s:%s - %s",
                          local_file, self.host, remote_file, error)
+            raise error
         else:
             logger.info("Copied local file %s from remote destination %s:%s",
                         local_file, self.host, remote_file)
 
-    @staticmethod
-    def _parent_path_split(file_path):
+    def _make_local_dir(self, dirpath):
+        if not os.path.exists(dirpath):
+            try:
+                os.makedirs(dirpath)
+            except OSError:
+                logger.error("Unable to create local directory structure for "
+                             "directory %s", dirpath)
+                raise
+
+    def _parent_path_split(self, file_path):
         try:
             destination = [_dir for _dir in file_path.split(os.path.sep)
                             if _dir][:-1][0]

--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -420,7 +420,10 @@ class SSHClient(object):
         if local_file.startswith(os.path.sep):
             destination = os.path.sep + destination
         if not os.path.exists(destination):
-            os.mkdir(destination)
+            try:
+                os.makedirs(destination)
+            except OSError:
+                logger.error("Unable to create local directory structure.")
         try:
             sftp.get(remote_file, local_file)
         except Exception, error:

--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -417,7 +417,6 @@ class SSHClient(object):
         destination = self._parent_path_split(local_file)
         self._make_local_dir(destination)
         try:
-            import ipdb; ipdb.set_trace()
             sftp.get(remote_file, local_file)
         except Exception, error:
             logger.error("Error occured copying file %s from remote destination %s:%s - %s",

--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -378,3 +378,48 @@ class SSHClient(object):
             raise error
         logger.info("Copied local file %s to remote destination %s:%s",
                     local_file, self.host, remote_file)
+
+    def _copy_dir_to_local(self, remote_dir, local_dir):
+        """Copies the remote directory to the local host."""
+        sftp = self._make_sftp()
+        file_list = sftp.listdir(remote_dir)
+        for file_name in file_list:
+            remote_path = os.path.join(remote_dir, file_name)
+            local_path = os.path.join(local_dir, file_name)
+            self.copy_file_to_local(remote_path, local_path, recurse=True)
+
+    def copy_file_to_local(self, remote_file, local_file, recurse=False):
+        """Copy remote file to local host via SFTP/SCP
+
+        Copy is done natively using SFTP/SCP version 2 protocol, no scp command \
+        is used or required.
+
+        :param remote_file: Remote filepath to copy the file from.
+        :type remote_file: str
+        :param local_file: Local filepath where the file will be copied.
+        :type local_file: str
+        :param recurse: Whether or not to recursively copy directories.
+        :type recurse: bool
+        """
+        sftp = self._make_sftp()
+        try:
+            sftp.listdir(remote_file)
+            remote_dir_exists = True
+        except IOError or OSError:
+            remote_dir_exists = False
+        if remote_dir_exists and recurse:
+            return self._copy_dir_to_local(remote_file, local_file)
+        destination = [_dir for _dir in local_file.split(os.path.sep)
+                       if _dir][:-1][0]
+        if local_file.startswith(os.path.sep):
+            destination = os.path.sep + destination
+        if not os.path.exists(destination):
+            os.mkdir(destination)
+        try:
+            sftp.get(remote_file, local_file)
+        except Exception, error:
+            logger.error("Error occured copying file %s from remote destination %s:%s - %s",
+                         local_file, self.host, remote_file, error)
+        else:
+            logger.info("Copied local file %s from remote destination %s:%s",
+                        local_file, self.host, remote_file)

--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -361,7 +361,9 @@ class SSHClient(object):
                              "directory.")
         sftp = self._make_sftp()
         destination = self._parent_path_split(remote_file)
-        if os.path.sep in remote_file:
+        try:
+            sftp.stat(destination)
+        except IOError:
             self.mkdir(sftp, destination)
         sftp.chdir()
         try:
@@ -427,8 +429,11 @@ class SSHClient(object):
 
     @staticmethod
     def _parent_path_split(file_path):
-        destination = [_dir for _dir in file_path.split(os.path.sep)
-                       if _dir][:-1][0]
-        if file_path.startswith(os.path.sep):
+        try:
+            destination = [_dir for _dir in file_path.split(os.path.sep)
+                            if _dir][:-1][0]
+        except IndexError:
+            destination = ''
+        if file_path.startswith(os.path.sep) or not destination:
             destination = os.path.sep + destination
         return destination

--- a/tests/test_pssh_client.py
+++ b/tests/test_pssh_client.py
@@ -362,6 +362,7 @@ class ParallelSSHClientTest(unittest.TestCase):
                         msg="SFTP copy failed")
         for filepath in [local_filename, remote_filename]:
             os.unlink(filepath)
+        shutil.rmtree(remote_test_dir)
         del client
     
     def test_pssh_client_directory(self):
@@ -472,6 +473,7 @@ class ParallelSSHClientTest(unittest.TestCase):
                         msg="SFTP copy failed")
         for filepath in [remote_filename, local_filename]:
             os.unlink(filepath)
+        shutil.rmtree(local_test_dir)
         del client
         server.join()
 

--- a/tests/test_pssh_client.py
+++ b/tests/test_pssh_client.py
@@ -450,6 +450,31 @@ class ParallelSSHClientTest(unittest.TestCase):
         for path in [local_test_path, remote_test_path]:
             shutil.rmtree(path)
     
+    def test_pssh_copy_file_to_local(self):
+        """Test parallel copy file to local host"""
+        test_file_data = 'test'
+        remote_filename = 'test_file'
+        local_test_dir, local_filename = 'local_test_dir', 'test_file_copy'
+        local_filename = os.path.sep.join([local_test_dir, local_filename])
+        test_file = open(remote_filename, 'w')
+        test_file.writelines([test_file_data + os.linesep])
+        test_file.close()
+        server = start_server({ self.fake_cmd : self.fake_resp },
+                              self.listen_socket)
+        client = ParallelSSHClient([self.host], port=self.listen_port,
+                                   pkey=self.user_key)
+        cmds = client.copy_file_to_local(remote_filename, local_filename)
+        cmds[0].get()
+        local_filename += '_' + self.host
+        self.assertTrue(os.path.isdir(local_test_dir),
+                        msg="SFTP create local directory failed")
+        self.assertTrue(os.path.isfile(local_filename),
+                        msg="SFTP copy failed")
+        for filepath in [remote_filename, local_filename]:
+            os.unlink(filepath)
+        del client
+        server.join()
+
     def test_pssh_pool_size(self):
         """Test setting pool size to non default values"""
         hosts = ['host-%01d' % d for d in xrange(5)]

--- a/tests/test_ssh_client.py
+++ b/tests/test_ssh_client.py
@@ -206,6 +206,78 @@ not match source %s" % (copied_file_data, test_file_data))
         self.assertRaises(ValueError, client.copy_file, local_test_path, remote_test_path)
         shutil.rmtree(local_test_path)
 
+    def test_ssh_client_sftp_from_remote(self):
+        """Test copying a file from a remote host to the local host. Copy
+        remote filename to local host, check that the data is intact, make a
+        directory on the localhost, then delete the file and directory."""
+        test_file_data = 'test'
+        remote_filename = 'test_remote'
+        local_test_dir, local_filename = 'local_test_dir', 'test_local'
+        local_filename = os.path.join(local_test_dir, local_filename)
+        remote_file = open(remote_filename, 'w')
+        remote_file.write(test_file_data)
+        remote_file.close()
+        client = SSHClient(self.host, port=self.listen_port,
+                           pkey=self.user_key)
+        client.copy_file_to_local(remote_filename, local_filename)
+        self.assertTrue(os.path.isdir(local_test_dir),
+                        msg="SFTP create local directory failed")
+        self.assertTrue(os.path.isfile(local_filename),
+                        msg="SFTP copy failed")
+        copied_file = open(local_filename, 'r')
+        copied_file_data = copied_file.readlines()[0].strip()
+        copied_file.close()
+        self.assertEqual(test_file_data, copied_file_data,
+                         msg="Data in destination file %s does \
+not match source %s" % (copied_file_data, test_file_data))
+        for filepath in [local_filename, remote_filename]:
+            os.remove(filepath)
+        os.rmdir(local_test_dir)
+        del client
+
+    def test_ssh_client_sftp_from_remote_directory(self):
+        """Tests copying remote files to local directory. Copy all the files
+        from the remote directory, then make sure they're all present."""
+        test_file_data = 'test'
+        remote_test_path = 'directory_test_remote'
+        local_test_path = 'directory_test_local'
+        os.mkdir(remote_test_path)
+        local_file_paths = []
+        for i in range(0, 10):
+            remote_file_path = os.path.join(remote_test_path, 'foo' + str(i))
+            local_file_path = os.path.join(local_test_path, 'foo' + str(i))
+            local_file_paths.append(local_file_path)
+            test_file = open(remote_file_path, 'w')
+            test_file.write(test_file_data)
+            test_file.close()
+        client = SSHClient(self.host, port=self.listen_port,
+                           pkey=self.user_key)
+        client.copy_file_to_local(remote_test_path, local_test_path, recurse=True)
+        for path in local_file_paths:
+            self.assertTrue(os.path.isfile(path))
+        shutil.rmtree(local_test_path)
+        shutil.rmtree(remote_test_path)
+
+    def test_ssh_client_remote_directory_no_recurse(self):
+        """Tests copying directories with SSH client. Copy all the files from
+        local directory to server, then make sure they are all present."""
+        test_file_data = 'test'
+        remote_test_path = 'directory_test'
+        local_test_path = 'directory_test_copied'
+        os.mkdir(remote_test_path)
+        local_file_paths = []
+        for i in range(0, 10):
+            remote_file_path = os.path.join(remote_test_path, 'foo' + str(i))
+            local_file_path = os.path.join(local_test_path, 'foo' + str(i))
+            local_file_paths.append(local_file_path)
+            test_file = open(remote_file_path, 'w')
+            test_file.write(test_file_data)
+            test_file.close()
+        client = SSHClient(self.host, port=self.listen_port,
+                           pkey=self.user_key)
+        self.assertRaises(ValueError, client.copy_file_to_local, remote_test_path, local_test_path)
+        shutil.rmtree(remote_test_path)
+
     def test_ssh_agent_authentication(self):
         """Test authentication via SSH agent.
         Do not provide public key to use when creating SSHClient,

--- a/tests/test_ssh_client.py
+++ b/tests/test_ssh_client.py
@@ -153,7 +153,7 @@ not match source %s" % (copied_file_data, test_file_data))
             os.rmdir(dirpath)
         del client
 
-    def test_ssh_client_directory(self):
+    def test_ssh_client_local_directory(self):
         """Tests copying directories with SSH client. Copy all the files from
         local directory to server, then make sure they are all present."""
         test_file_data = 'test'
@@ -180,6 +180,28 @@ not match source %s" % (copied_file_data, test_file_data))
             self.assertTrue(os.path.isfile(path))
         shutil.rmtree(local_test_path)
         shutil.rmtree(remote_test_path)
+
+    def test_ssh_client_copy_remote_directory(self):
+        """Tests copying a remote directory to the localhost"""
+        remote_test_directory = 'remote_test_dir'
+        local_test_directory = 'local_test_dir'
+        os.mkdir(remote_test_directory)
+        test_files = []
+        for i in range(0, 10):
+            file_name = 'foo' + str(i)
+            test_files.append(file_name)
+            file_path = os.path.join(remote_test_directory, file_name)
+            test_file = open(file_path, 'w')
+            test_file.write('test')
+            test_file.close()
+        client = SSHClient(self.host, port=self.listen_port,
+                           pkey=self.user_key)
+        client.copy_file_to_local(remote_test_directory, local_test_directory, recurse=True)
+        for test_file in test_files:
+            file_path = os.path.join(local_test_directory, test_file)
+            self.assertTrue(os.path.exists(file_path))
+        shutil.rmtree(remote_test_directory)
+        shutil.rmtree(local_test_directory)
 
     def test_ssh_client_directory_no_recurse(self):
         """Tests copying directories with SSH client. Copy all the files from

--- a/tests/test_ssh_client.py
+++ b/tests/test_ssh_client.py
@@ -185,6 +185,11 @@ not match source %s" % (copied_file_data, test_file_data))
         """Tests copying a remote directory to the localhost"""
         remote_test_directory = 'remote_test_dir'
         local_test_directory = 'local_test_dir'
+        for path in [local_test_path, remote_test_path]:
+            try:
+                shutil.rmtree(path)
+            except OSError:
+                pass
         os.mkdir(remote_test_directory)
         test_files = []
         for i in range(0, 10):
@@ -263,11 +268,17 @@ not match source %s" % (copied_file_data, test_file_data))
         test_file_data = 'test'
         remote_test_path = 'directory_test_remote'
         local_test_path = 'directory_test_local'
+        for path in [local_test_path, remote_test_path]:
+            try:
+                shutil.rmtree(path)
+            except OSError:
+                pass
         os.mkdir(remote_test_path)
+        os.mkdir(os.path.join(remote_test_path, 'subdir'))
         local_file_paths = []
         for i in range(0, 10):
-            remote_file_path = os.path.join(remote_test_path, 'foo' + str(i))
-            local_file_path = os.path.join(local_test_path, 'foo' + str(i))
+            remote_file_path = os.path.join(remote_test_path, 'subdir', 'foo' + str(i))
+            local_file_path = os.path.join(local_test_path, 'subdir', 'foo' + str(i))
             local_file_paths.append(local_file_path)
             test_file = open(remote_file_path, 'w')
             test_file.write(test_file_data)
@@ -286,6 +297,10 @@ not match source %s" % (copied_file_data, test_file_data))
         test_file_data = 'test'
         remote_test_path = 'directory_test'
         local_test_path = 'directory_test_copied'
+        try:
+            shutil.rmtree(remote_test_path)
+        except OSError:
+            pass
         os.mkdir(remote_test_path)
         local_file_paths = []
         for i in range(0, 10):

--- a/tests/test_ssh_client.py
+++ b/tests/test_ssh_client.py
@@ -185,28 +185,39 @@ not match source %s" % (copied_file_data, test_file_data))
         """Tests copying a remote directory to the localhost"""
         remote_test_directory = 'remote_test_dir'
         local_test_directory = 'local_test_dir'
-        for path in [local_test_path, remote_test_path]:
+        for path in [remote_test_directory, local_test_directory]:
             try:
                 shutil.rmtree(path)
             except OSError:
                 pass
         os.mkdir(remote_test_directory)
         test_files = []
+        test_file_data = 'test'
         for i in range(0, 10):
             file_name = 'foo' + str(i)
             test_files.append(file_name)
             file_path = os.path.join(remote_test_directory, file_name)
             test_file = open(file_path, 'w')
-            test_file.write('test')
+            test_file.write(test_file_data)
             test_file.close()
         client = SSHClient(self.host, port=self.listen_port,
                            pkey=self.user_key)
-        client.copy_file_to_local(remote_test_directory, local_test_directory, recurse=True)
-        for test_file in test_files:
-            file_path = os.path.join(local_test_directory, test_file)
-            self.assertTrue(os.path.exists(file_path))
-        shutil.rmtree(remote_test_directory)
-        shutil.rmtree(local_test_directory)
+        try:
+            self.assertRaises(ValueError, client.copy_remote_file, remote_test_directory, local_test_directory)
+            client.copy_remote_file(remote_test_directory, local_test_directory, recurse=True)
+            for test_file in test_files:
+                file_path = os.path.join(local_test_directory, test_file)
+                self.assertTrue(os.path.isfile(file_path))
+                copied_file = open(file_path, 'r')
+                copied_file_data = copied_file.read().strip()
+                copied_file.close()
+                self.assertEqual(test_file_data, copied_file_data,
+                                 msg="Data in destination file %s does "
+                                 "not match source %s" % (
+                                     copied_file_data, test_file_data))
+        finally:
+            shutil.rmtree(remote_test_directory)
+            shutil.rmtree(local_test_directory)
 
     def test_ssh_client_directory_no_recurse(self):
         """Tests copying directories with SSH client. Copy all the files from
@@ -232,88 +243,6 @@ not match source %s" % (copied_file_data, test_file_data))
                            pkey=self.user_key)
         self.assertRaises(ValueError, client.copy_file, local_test_path, remote_test_path)
         shutil.rmtree(local_test_path)
-
-    def test_ssh_client_sftp_from_remote(self):
-        """Test copying a file from a remote host to the local host. Copy
-        remote filename to local host, check that the data is intact, make a
-        directory on the localhost, then delete the file and directory."""
-        test_file_data = 'test'
-        remote_filename = 'test_remote'
-        local_test_dir, local_filename = 'local_test_dir', 'test_local'
-        local_filename = os.path.join(local_test_dir, local_filename)
-        remote_file = open(remote_filename, 'w')
-        remote_file.write(test_file_data)
-        remote_file.close()
-        client = SSHClient(self.host, port=self.listen_port,
-                           pkey=self.user_key)
-        client.copy_file_to_local(remote_filename, local_filename)
-        self.assertTrue(os.path.isdir(local_test_dir),
-                        msg="SFTP create local directory failed")
-        self.assertTrue(os.path.isfile(local_filename),
-                        msg="SFTP copy failed")
-        copied_file = open(local_filename, 'r')
-        copied_file_data = copied_file.readlines()[0].strip()
-        copied_file.close()
-        self.assertEqual(test_file_data, copied_file_data,
-                         msg="Data in destination file %s does \
-not match source %s" % (copied_file_data, test_file_data))
-        for filepath in [local_filename, remote_filename]:
-            os.remove(filepath)
-        os.rmdir(local_test_dir)
-        del client
-
-    def test_ssh_client_sftp_from_remote_directory(self):
-        """Tests copying remote files to local directory. Copy all the files
-        from the remote directory, then make sure they're all present."""
-        test_file_data = 'test'
-        remote_test_path = 'directory_test_remote'
-        local_test_path = 'directory_test_local'
-        for path in [local_test_path, remote_test_path]:
-            try:
-                shutil.rmtree(path)
-            except OSError:
-                pass
-        os.mkdir(remote_test_path)
-        os.mkdir(os.path.join(remote_test_path, 'subdir'))
-        local_file_paths = []
-        for i in range(0, 10):
-            remote_file_path = os.path.join(remote_test_path, 'subdir', 'foo' + str(i))
-            local_file_path = os.path.join(local_test_path, 'subdir', 'foo' + str(i))
-            local_file_paths.append(local_file_path)
-            test_file = open(remote_file_path, 'w')
-            test_file.write(test_file_data)
-            test_file.close()
-        client = SSHClient(self.host, port=self.listen_port,
-                           pkey=self.user_key)
-        client.copy_file_to_local(remote_test_path, local_test_path, recurse=True)
-        for path in local_file_paths:
-            self.assertTrue(os.path.isfile(path))
-        shutil.rmtree(local_test_path)
-        shutil.rmtree(remote_test_path)
-
-    def test_ssh_client_remote_directory_no_recurse(self):
-        """Tests copying directories with SSH client. Copy all the files from
-        local directory to server, then make sure they are all present."""
-        test_file_data = 'test'
-        remote_test_path = 'directory_test'
-        local_test_path = 'directory_test_copied'
-        try:
-            shutil.rmtree(remote_test_path)
-        except OSError:
-            pass
-        os.mkdir(remote_test_path)
-        local_file_paths = []
-        for i in range(0, 10):
-            remote_file_path = os.path.join(remote_test_path, 'foo' + str(i))
-            local_file_path = os.path.join(local_test_path, 'foo' + str(i))
-            local_file_paths.append(local_file_path)
-            test_file = open(remote_file_path, 'w')
-            test_file.write(test_file_data)
-            test_file.close()
-        client = SSHClient(self.host, port=self.listen_port,
-                           pkey=self.user_key)
-        self.assertRaises(ValueError, client.copy_file_to_local, remote_test_path, local_test_path)
-        shutil.rmtree(remote_test_path)
 
     def test_ssh_agent_authentication(self):
         """Test authentication via SSH agent.


### PR DESCRIPTION
Re-raising PR with upstream master branch merged in.

From previous #47 PR:

> Adds support for copying files from remote hosts to local host as described in #40.
> 
> A new method, `copy_file_to_local`, has been added to both `pssh_client` and `ssh_client`.  In `ssh_client`, its logic is pretty similar to `copy_file`, but was different enough that I figured it would be better to create a new method rather than make `copy_file` more complex. In `pssh_client`, the logic is almost identical between `copy_file` and `copy_file_to_local`; the method was duplicated to maintain the pattern between `ssh_client` and `pssh_client`.
> 
> While I think keeping `copy_file` simple and creating a new method is better, I also see the benefit of using one method to perform both functions, and am completely open to rolling the two functions together.
> 
> Filenames are de-duplicated by appending an underscore followed by the hostname when using `pssh_client` to copy files to the local host.
