### PR TITLE
Copy exceptions

### DIFF
--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -290,8 +290,9 @@ class SSHClient(object):
         try:
             sftp.mkdir(directory)
         except IOError, error:
-            logger.error("Error occured creating directory %s on %s - %s",
-                         directory, self.host, error)
+            msg = "Error occured creating directory %s on %s - %s"
+            logger.error(msg, directory, self.host, error)
+            raise IOError(msg, directory, self.host, error)
         logger.debug("Creating remote directory %s", directory)
         return True
 

--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -372,6 +372,6 @@ class SSHClient(object):
         except Exception, error:
             logger.error("Error occured copying file %s to remote destination %s:%s - %s",
                          local_file, self.host, remote_file, error)
-        else:
-            logger.info("Copied local file %s to remote destination %s:%s",
-                        local_file, self.host, remote_file)
+            raise error
+        logger.info("Copied local file %s to remote destination %s:%s",
+                    local_file, self.host, remote_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 paramiko>=1.12,!=1.16.0
-gevent>=1.1rc3
+gevent<=1.1; python_version < '3'
+gevent>=1.1; python_version >= '3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools>=21.0
 paramiko>=1.12,!=1.16.0
 gevent<=1.1; python_version < '3'
 gevent>=1.1; python_version >= '3'

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,9 @@ setup(name='parallel-ssh',
       packages=find_packages('.', exclude=(
           'embedded_server', 'embedded_server.*')),
       install_requires=['paramiko', 'gevent'],
+      extras_require={':python_version < "3"': ['gevent<=1.1'],
+                      ':python_version >= "3"': ['gevent>=1.1'],
+                      },
       classifiers=[
         'License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)',
         'Intended Audience :: Developers',


### PR DESCRIPTION
* Adds re-raising exceptions on SFTP errors at `SSHClient.copy_file` and `SSHClient.mkdir`
* Updates gevent requirements for py2.6
