### PR TITLE
Make gevent.monkey.patch_all() optional

### DIFF
--- a/pssh/pssh_client.py
+++ b/pssh/pssh_client.py
@@ -22,7 +22,6 @@ import sys
 if 'threading' in sys.modules:
     del sys.modules['threading']
 from gevent import monkey
-monkey.patch_all()
 import logging
 import gevent.pool
 import gevent.hub
@@ -51,7 +50,7 @@ class ParallelSSHClient(object):
                  forward_ssh_agent=True, num_retries=DEFAULT_RETRIES, timeout=120,
                  pool_size=10, proxy_host=None, proxy_port=22, proxy_user=None,
                  proxy_password=None, proxy_pkey=None,
-                 agent=None, allow_agent=True, host_config=None, channel_timeout=None):
+                 agent=None, allow_agent=True, host_config=None, channel_timeout=None, monkey_patch=True):
         """
         :param hosts: Hosts to connect to
         :type hosts: list(str)
@@ -111,6 +110,8 @@ class ParallelSSHClient(object):
         :param allow_agent: (Optional) set to False to disable connecting to \
         the SSH agent
         :type allow_agent: bool
+        :param monkey_patch: (Optional) whether to use gevent.monkey.patch_all()
+        :type monkey_patch: bool
         
         **Example Usage**
         
@@ -299,6 +300,10 @@ class ParallelSSHClient(object):
           
           Connection is terminated.
         """
+
+        if monkey_patch:
+            monkey.patch_all()
+
         self.pool_size = pool_size
         self.pool = gevent.pool.Pool(size=self.pool_size)
         self.hosts = hosts


### PR DESCRIPTION
When using the standard monkey.patch_all() in combination with [Dask Distributed](https://github.com/dask/distributed) it would block forever. Commenting out monkey.patch_all() makes my script work seamlessly; thought I'd submit a PR making the patch_all() optional (default True of course) in case others wish to make it optional as well. Love the library though, thank you! :)

```
Exception in thread Thread-7:
Traceback (most recent call last):
  File "/home/milesg/anaconda2/envs/clusterclyde/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/home/milesg/anaconda2/envs/clusterclyde/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/milesg/anaconda2/envs/clusterclyde/lib/python2.7/site-packages/zmq/eventloop/ioloop.py", line 177, in start
    super(ZMQIOLoop, self).start()
  File "/home/milesg/anaconda2/envs/clusterclyde/lib/python2.7/site-packages/tornado/ioloop.py", line 862, in start
    event_pairs = self._impl.poll(poll_timeout)
  File "/home/milesg/anaconda2/envs/clusterclyde/lib/python2.7/site-packages/zmq/eventloop/ioloop.py", line 122, in poll
    z_events = self._poller.poll(1000*timeout)
  File "/home/milesg/anaconda2/envs/clusterclyde/lib/python2.7/site-packages/zmq/sugar/poll.py", line 99, in poll
    return zmq_poll(self.sockets, timeout=timeout)
  File "zmq/backend/cython/_poll.pyx", line 115, in zmq.backend.cython._poll.zmq_poll (zmq/backend/cython/_poll.c:1880)
  File "zmq/backend/cython/checkrc.pxd", line 12, in zmq.backend.cython.checkrc._check_rc (zmq/backend/cython/_poll.c:2262)
    PyErr_CheckSignals()
KeyboardInterrupt

KeyboardInterrupt

KeyboardInterrupt                         Traceback (most recent call last)
<ipython-input-6-9b932dd2c172> in <module>()
----> 1 c = Client(address='52.23.206.61:8786')
      2 c

/home/milesg/anaconda2/envs/clusterclyde/lib/python2.7/site-packages/distributed/client.pyc in __init__(self, address, start, loop, timeout, set_as_default)
    310 
    311         if start:
--> 312             self.start(timeout=timeout)
    313 
    314     def __str__(self):

/home/milesg/anaconda2/envs/clusterclyde/lib/python2.7/site-packages/distributed/client.pyc in start(self, **kwargs)
    338         self.loop.add_callback(pc.start)
    339         _global_client[0] = self
--> 340         sync(self.loop, self._start, **kwargs)
    341         self.status = 'running'
    342 

/home/milesg/anaconda2/envs/clusterclyde/lib/python2.7/site-packages/distributed/utils.pyc in sync(loop, func, *args, **kwargs)
    130     a = loop.add_callback(f)
    131     while not e.is_set():
--> 132         e.wait(1000000)
    133     if error[0]:
    134         six.reraise(type(error[0]), error[0], traceback[0])

/home/milesg/anaconda2/envs/clusterclyde/lib/python2.7/threading.pyc in wait(self, timeout)
    612         with self.__cond:
    613             if not self.__flag:
--> 614                 self.__cond.wait(timeout)
    615             return self.__flag
    616 

/home/milesg/anaconda2/envs/clusterclyde/lib/python2.7/threading.pyc in wait(self, timeout)
    357                         break
    358                     delay = min(delay * 2, remaining, .05)
--> 359                     _sleep(delay)
    360                 if not gotit:
    361                     if __debug__:

/home/milesg/anaconda2/envs/clusterclyde/lib/python2.7/site-packages/gevent/hub.pyc in sleep(seconds, ref)
    192         waiter.get()
    193     else:
--> 194         hub.wait(loop.timer(seconds, ref=ref))
    195 
    196 

/home/milesg/anaconda2/envs/clusterclyde/lib/python2.7/site-packages/gevent/hub.pyc in wait(self, watcher)
    628         watcher.start(waiter.switch, unique)
    629         try:
--> 630             result = waiter.get()
    631             if result is not unique:
    632                 raise InvalidSwitchError('Invalid switch into %s: %r (expected %r)' % (getcurrent(), result, unique))

/home/milesg/anaconda2/envs/clusterclyde/lib/python2.7/site-packages/gevent/hub.pyc in get(self)
    876             self.greenlet = getcurrent()
    877             try:
--> 878                 return self.hub.switch()
    879             finally:
    880                 self.greenlet = None

/home/milesg/anaconda2/envs/clusterclyde/lib/python2.7/site-packages/gevent/hub.pyc in switch(self)
    607         if switch_out is not None:
    608             switch_out()
--> 609         return greenlet.switch(self)
    610 
    611     def switch_out(self):

KeyboardInterrupt: 

```



