### PR TITLE
Allow per-host proxy configuration

### DIFF
--- a/pssh/pssh_client.py
+++ b/pssh/pssh_client.py
@@ -674,9 +674,9 @@ class ParallelSSHClient(object):
     def _get_host_config_values(self, host, properties):
         """Return SSH config for a given host, including any overrides."""
         if host in self.host_config:
-            return {p: self.host_config[host][p] for p in properties}
+            return dict((p, self.host_config[host][p]) for p in properties)
         else:
-            return {p: getattr(self, p) for p in properties}
+            return dict((p, getattr(self, p)) for p in properties)
 
     def _exec_command(self, host, command, sudo=False, user=None,
                       shell=None, use_shell=True, use_pty=True):


### PR DESCRIPTION
The host_config parameter to the ParallelSSHClient constructor would
only hold a few of the possible configuration parameters. Now it allows
proxy_host, proxy_port, proxy_user, proxy_password and proxy_private_key
to all be overridden for different hosts.