### PR TITLE
Add explicit tracking of hosts for pssh greenlets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,7 +194,7 @@ To copy a local file to remote hosts in parallel:
   enable_logger(logger)
   hosts = ['myhost1', 'myhost2']
   client = ParallelSSHClient(hosts)
-  cmds = client.copy_file('../test', 'test_dir/test')
+  hosts, cmds = zip(*(client.copy_file('../test', 'test_dir/test')))
   joinall(cmds, raise_error=True)
 
 :Output:

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -426,14 +426,14 @@ To copy the local file with relative path ``../test`` to the remote relative pat
    
    client = ParallelSSHClient(hosts)
    
-   greenlets = client.copy_file('../test', 'test_dir/test')
+   _hosts, greenlets = zip(*(client.copy_file('../test', 'test_dir/test')))
    joinall(greenlets, raise_error=True)
 
 To recursively copy directory structures, enable the ``recurse`` flag:
 
 .. code-block:: python
 
-   greenlets = client.copy_file('my_dir', 'my_dir', recurse=True)
+   _hosts, greenlets = zip(*(client.copy_file('my_dir', 'my_dir', recurse=True)))
    joinall(greenlets, raise_error=True)
 
 .. seealso::
@@ -454,7 +454,7 @@ Copying remote files in parallel requires that file names are de-duplicated othe
    
    client = ParallelSSHClient(hosts)
    
-   greenlets = client.copy_remote_file('remote.file', 'local.file')
+   _hosts, greenlets = zip(*(client.copy_remote_file('remote.file', 'local.file')))
    joinall(greenlets, raise_error=True)
 
 The above will create files ``local.file_host1`` where ``host1`` is the host name the file was copied from.

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -186,9 +186,8 @@ Commands last executed by ``run_command`` can also be retrieved from the ``cmds`
 
    client.run_command('uname')
    output = {}
-   for i, host in enumerate(hosts):
-       cmd = self.cmds[i]
-       client.get_output(cmd, output)
+   for host, cmd in client.cmds:
+       client.get_output(host, cmd, output)
        print("Got output for host %s from cmd %s" % (host, cmd))
 
 *New in 1.2.0*

--- a/examples/pssh_local.py
+++ b/examples/pssh_local.py
@@ -51,7 +51,7 @@ def test_parallel():
     output = client.run_command('ls -ltrh')
     client.join(output)
     pprint(output)
-    cmds = client.copy_file('../test', 'test_dir/test')
+    client.copy_file('../test', 'test_dir/test')
     client.pool.join()
 
 if __name__ == "__main__":


### PR DESCRIPTION
Specific changes, for `ParallelSSHClient`:
- `run_command`, `copy_file`, and `copy_remote_file` now each return a
  list of (host, greenlet) tuples instead of a list of greenlets.
- The `cmds` attribute now stores a list of (host, greenlet) tuples
  instead of a list of greenlets.
- `get_output` now requires a `host` argument, because the above changes
  mean the host is always known, and having access to it enables the
  function to *always* correctly update the host output structure, even
  in cases where the `cmd` greenlet threw an exception with no `host`
  argument.
- Modified tests to work with the above changes.

Overall, this results in a simplification of usage where parallel
command/copy exceptions are being explicitly, individually handled by
the calling code, and only a very slight increase in complexity for
usages where such exceptions are being ignored, or are being managed for
an entire group (e.g. via `joinall(..., raise_error=True)` or
`run_command(..., stop_on_errors=True)`).


## Motivation
My own usage for this right now is in capturing and handling SFTP failures per-host, e.g. something along the lines of:
```python
for host, greenlet in client.copy_file(some_file, a_file_name):
    try:
        greenlet.get()
    except Exception as ex:
        logging.error("SFTP failure for '{}', caught exception:\n{}".format(
            host, ex))
        handle_sftp_exception(host, ex)
```