### PR TITLE
Fix infinite loop when LIBSS2_EAGAIN error returned

### DIFF
--- a/pssh/clients/native/single.py
+++ b/pssh/clients/native/single.py
@@ -707,7 +707,7 @@ class SSHClient(object):
             local_fh.write(data)
             while total < fileinfo.st_size:
                 size, data = file_chan.read(size=fileinfo.st_size - total)
-                while size == LIBSSH2_ERROR_EAGAIN:
+                if size == LIBSSH2_ERROR_EAGAIN:
                     wait_select(self.session)
                     continue
                 total += size


### PR DESCRIPTION
When using `scp_recv()` there was an infinite loop when `LIBSSH2_ERROR_EAGAIN` is returned. 