### PR TITLE
documentation/docstring fix method ParallelSSHClient

### DIFF
--- a/pssh/clients/native/parallel.py
+++ b/pssh/clients/native/parallel.py
@@ -80,7 +80,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
         :type pool_size: int
         :param host_config: (Optional) Per-host configuration for cases where
           not all hosts use the same configuration.
-        :type host_config: list, dict
+        :type host_config: list
         :param allow_agent: (Optional) set to False to disable connecting to
           the system's SSH agent.
         :type allow_agent: bool

--- a/pssh/clients/native/parallel.py
+++ b/pssh/clients/native/parallel.py
@@ -80,7 +80,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
         :type pool_size: int
         :param host_config: (Optional) Per-host configuration for cases where
           not all hosts use the same configuration.
-        :type host_config: dict
+        :type host_config: list, dict
         :param allow_agent: (Optional) set to False to disable connecting to
           the system's SSH agent.
         :type allow_agent: bool


### PR DESCRIPTION
argument `host_config` of function `ParallelSSHClient` actually accepts dict or list... super confusion with this example https://parallel-ssh.readthedocs.io/en/latest/advanced.html?highlight=username#per-host-configuration 