### PR TITLE
Use also HostConfig for host_config dict values

### DIFF
--- a/pssh/clients/base/parallel.py
+++ b/pssh/clients/base/parallel.py
@@ -24,6 +24,7 @@ import gevent.pool
 from gevent import joinall, spawn, Timeout as GTimeout
 from gevent.hub import Hub
 
+from ...config import HostConfig
 from ...constants import DEFAULT_RETRIES, RETRY_DELAY
 from ...exceptions import HostArgumentError, Timeout, ShellError
 from ...output import HostOutput
@@ -234,22 +235,19 @@ class BaseParallelSSHClient(object):
                 getattr(self, 'proxy_host', None), \
                 getattr(self, 'proxy_port', None), getattr(self, 'proxy_user', None), \
                 getattr(self, 'proxy_password', None), getattr(self, 'proxy_pkey', None)
-        elif isinstance(self.host_config, list):
+        if isinstance(self.host_config, list):
             config = self.host_config[host_i]
-            return config.user or self.user, config.port or self.port, \
-                config.password or self.password, config.private_key or self.pkey, \
-                config.proxy_host or getattr(self, 'proxy_host', None), \
-                config.proxy_port or getattr(self, 'proxy_port', None), \
-                config.proxy_user or getattr(self, 'proxy_user', None), \
-                config.proxy_password or getattr(self, 'proxy_password', None), \
-                config.proxy_pkey or getattr(self, 'proxy_pkey', None)
         elif isinstance(self.host_config, dict):
-            _user = self.host_config.get(host, {}).get('user', self.user)
-            _port = self.host_config.get(host, {}).get('port', self.port)
-            _password = self.host_config.get(host, {}).get(
-                'password', self.password)
-            _pkey = self.host_config.get(host, {}).get('private_key', self.pkey)
-            return _user, _port, _password, _pkey, None, None, None, None, None
+            config = self.host_config.get(host, HostConfig())
+        else:
+            return
+        return config.user or self.user, config.port or self.port, \
+            config.password or self.password, config.private_key or self.pkey, \
+            config.proxy_host or getattr(self, 'proxy_host', None), \
+            config.proxy_port or getattr(self, 'proxy_port', None), \
+            config.proxy_user or getattr(self, 'proxy_user', None), \
+            config.proxy_password or getattr(self, 'proxy_password', None), \
+            config.proxy_pkey or getattr(self, 'proxy_pkey', None)
 
     def _run_command(self, host_i, host, command, sudo=False, user=None,
                      shell=None, use_pty=False,

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -946,7 +946,7 @@ class ParallelSSHClientTest(unittest.TestCase):
             host_config[host].password = password
             host_config[host].private_key = self.user_key
             servers.append(server)
-        host_config[hosts[1][0]]['private_key'] = fake_key
+        host_config[hosts[1][0]].private_key = fake_key
         client = ParallelSSHClient([h for h, _ in hosts],
                                    host_config=host_config,
                                    num_retries=1)

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -934,18 +934,17 @@ class ParallelSSHClientTest(unittest.TestCase):
         """Test per-host configuration functionality of ParallelSSHClient"""
         hosts = [('127.0.0.%01d' % n, self.make_random_port())
                  for n in range(1,3)]
-        host_config = dict.fromkeys([h for h,_ in hosts])
+        host_config = {h:HostConfig() for h,_ in hosts}
         servers = []
         password = 'overriden_pass'
         fake_key = 'FAKE KEY'
         for host, port in hosts:
             server = OpenSSHServer(listen_ip=host, port=port)
             server.start_server()
-            host_config[host] = {}
-            host_config[host]['port'] = port
-            host_config[host]['user'] = self.user
-            host_config[host]['password'] = password
-            host_config[host]['private_key'] = self.user_key
+            host_config[host].port = port
+            host_config[host].user = self.user
+            host_config[host].password = password
+            host_config[host].private_key = self.user_key
             servers.append(server)
         host_config[hosts[1][0]]['private_key'] = fake_key
         client = ParallelSSHClient([h for h, _ in hosts],


### PR DESCRIPTION
When `host_config` is a `dict`, I propose to use a HostConfig object for every value instead of another dict.

The function returns `None` in case it does not match a known class for host_config. This is to mimic the existing behaviour.