### PR TITLE
Cleanup socket on connection error/timeout

### DIFF
--- a/pssh/clients/base/single.py
+++ b/pssh/clients/base/single.py
@@ -302,8 +302,12 @@ class BaseSSHClient(object):
         try:
             self.sock.connect(sock_addr)
         except ConnectionRefusedError:
+            self.sock.shutdown(socket.SHUT_RDWR)
+            self.sock.close()
             raise
         except sock_error as ex:
+            self.sock.shutdown(socket.SHUT_RDWR)
+            self.sock.close()
             logger.error("Error connecting to host '%s:%s' - retry %s/%s",
                          host, port, retries, self.num_retries)
             while retries < self.num_retries:


### PR DESCRIPTION
When constructing a connection to a server, and the server is not responsive, the socket is not closed in a timely fashion and can cause a secondary exception when cleaning up in the exception handler due to the resource leak.  This is 

ConnectionError: ("Error connecting to host '%s:%s' - %s - retry %s/%s", 'kg-meter2', 22, 'timed out', 3, 3)
E               
E               During handling of the above exception, another exception occurred:
E               
E               Traceback (most recent call last):
E                 File "/home/kgodwin/.local/lib/python3.8/site-packages/_pytest/unraisableexception.py", line 43, in _hook
E                   self.unraisable = unraisable
E               ResourceWarning: unclosed <socket object, fd=23, family=2, type=1, proto=0>
