### PR TITLE
Add optional alias parameter to host config

### DIFF
--- a/pssh/clients/base/parallel.py
+++ b/pssh/clients/base/parallel.py
@@ -240,7 +240,7 @@ class BaseParallelSSHClient(object):
                 ex = Timeout()
             if raise_error:
                 raise ex
-            return HostOutput(host=host, exception=ex, alias=alias)
+            return HostOutput(host, None, None, None, exception=ex, alias=alias)
 
     def get_last_output(self, cmds=None):
         """Get output for last commands executed by ``run_command``.

--- a/pssh/clients/base/parallel.py
+++ b/pssh/clients/base/parallel.py
@@ -231,7 +231,7 @@ class BaseParallelSSHClient(object):
 
     def _get_output_from_greenlet(self, cmd_i, cmd, raise_error=False):
         host = self.hosts[cmd_i]
-        alias = self._get_host_config(host_i, _).alias
+        alias = self._get_host_config(cmd_i, _).alias
         try:
             host_out = cmd.get()
             return host_out

--- a/pssh/clients/base/parallel.py
+++ b/pssh/clients/base/parallel.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 class BaseParallelSSHClient(object):
     """Parallel client base class."""
 
-    def __init__(self, hosts, user=None, password=None, port=None, pkey=None,
+    def __init__(self, hosts, user=None, password=None, port=None, pkey=None, alias=None,
                  allow_agent=True,
                  num_retries=DEFAULT_RETRIES,
                  timeout=120, pool_size=10,
@@ -64,6 +64,7 @@ class BaseParallelSSHClient(object):
         self.user = user
         self.password = password
         self.port = port
+        self.alias = alias
         self.pkey = pkey
         self.num_retries = num_retries
         self.timeout = timeout
@@ -259,7 +260,7 @@ class BaseParallelSSHClient(object):
     def _get_host_config(self, host_i, host):
         if self.host_config is None:
             config = HostConfig(
-                user=self.user, port=self.port, password=self.password, private_key=self.pkey,
+                user=self.user, port=self.port, password=self.password, private_key=self.pkey, alias=self.alias,
                 allow_agent=self.allow_agent, num_retries=self.num_retries, retry_delay=self.retry_delay,
                 timeout=self.timeout, identity_auth=self.identity_auth, proxy_host=self.proxy_host,
                 proxy_port=self.proxy_port, proxy_user=self.proxy_user, proxy_password=self.proxy_password,

--- a/pssh/clients/base/parallel.py
+++ b/pssh/clients/base/parallel.py
@@ -231,6 +231,7 @@ class BaseParallelSSHClient(object):
 
     def _get_output_from_greenlet(self, cmd_i, cmd, raise_error=False):
         host = self.hosts[cmd_i]
+        alias = self._get_host_config(host_i, _).alias
         try:
             host_out = cmd.get()
             return host_out
@@ -239,8 +240,7 @@ class BaseParallelSSHClient(object):
                 ex = Timeout()
             if raise_error:
                 raise ex
-            return HostOutput(host, None, None, None,
-                              exception=ex)
+            return HostOutput(host=host,exception=ex, alias=alias)
 
     def get_last_output(self, cmds=None):
         """Get output for last commands executed by ``run_command``.

--- a/pssh/clients/base/parallel.py
+++ b/pssh/clients/base/parallel.py
@@ -272,6 +272,7 @@ class BaseParallelSSHClient(object):
                 gssapi_server_identity=self.gssapi_server_identity,
                 gssapi_client_identity=self.gssapi_client_identity,
                 gssapi_delegate_credentials=self.gssapi_delegate_credentials,
+                alias=None,
             )
             return config
         elif not isinstance(self.host_config, list):

--- a/pssh/clients/base/parallel.py
+++ b/pssh/clients/base/parallel.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 class BaseParallelSSHClient(object):
     """Parallel client base class."""
 
-    def __init__(self, hosts, user=None, password=None, port=None, pkey=None, alias=None,
+    def __init__(self, hosts, user=None, password=None, port=None, pkey=None,
                  allow_agent=True,
                  num_retries=DEFAULT_RETRIES,
                  timeout=120, pool_size=10,
@@ -64,7 +64,6 @@ class BaseParallelSSHClient(object):
         self.user = user
         self.password = password
         self.port = port
-        self.alias = alias
         self.pkey = pkey
         self.num_retries = num_retries
         self.timeout = timeout
@@ -199,7 +198,7 @@ class BaseParallelSSHClient(object):
 
     def run_command(self, command, user=None, stop_on_errors=True,
                     host_args=None, use_pty=False, shell=None,
-                    encoding='utf-8', alias=None,
+                    encoding='utf-8',
                     *args, **kwargs):
         if host_args:
             try:
@@ -260,7 +259,7 @@ class BaseParallelSSHClient(object):
     def _get_host_config(self, host_i, host):
         if self.host_config is None:
             config = HostConfig(
-                user=self.user, port=self.port, password=self.password, private_key=self.pkey, alias=self.alias,
+                user=self.user, port=self.port, password=self.password, private_key=self.pkey,
                 allow_agent=self.allow_agent, num_retries=self.num_retries, retry_delay=self.retry_delay,
                 timeout=self.timeout, identity_auth=self.identity_auth, proxy_host=self.proxy_host,
                 proxy_port=self.proxy_port, proxy_user=self.proxy_user, proxy_password=self.proxy_password,

--- a/pssh/clients/base/parallel.py
+++ b/pssh/clients/base/parallel.py
@@ -231,7 +231,7 @@ class BaseParallelSSHClient(object):
 
     def _get_output_from_greenlet(self, cmd_i, cmd, raise_error=False):
         host = self.hosts[cmd_i]
-        alias = self.host_config[cmd_i].alias
+        alias = self._get_host_config(cmd_i, host).alias
         try:
             host_out = cmd.get()
             return host_out

--- a/pssh/clients/base/parallel.py
+++ b/pssh/clients/base/parallel.py
@@ -199,7 +199,7 @@ class BaseParallelSSHClient(object):
 
     def run_command(self, command, user=None, stop_on_errors=True,
                     host_args=None, use_pty=False, shell=None,
-                    encoding='utf-8',
+                    encoding='utf-8', alias=None,
                     *args, **kwargs):
         if host_args:
             try:

--- a/pssh/clients/base/parallel.py
+++ b/pssh/clients/base/parallel.py
@@ -231,7 +231,7 @@ class BaseParallelSSHClient(object):
 
     def _get_output_from_greenlet(self, cmd_i, cmd, raise_error=False):
         host = self.hosts[cmd_i]
-        alias = self._get_host_config(cmd_i, 'doesnt matter').alias
+        alias = self.host_config[cmd_i].alias
         try:
             host_out = cmd.get()
             return host_out

--- a/pssh/clients/base/parallel.py
+++ b/pssh/clients/base/parallel.py
@@ -231,7 +231,7 @@ class BaseParallelSSHClient(object):
 
     def _get_output_from_greenlet(self, cmd_i, cmd, raise_error=False):
         host = self.hosts[cmd_i]
-        alias = self._get_host_config(cmd_i, _).alias
+        alias = self._get_host_config(cmd_i, 'doesnt matter').alias
         try:
             host_out = cmd.get()
             return host_out
@@ -240,7 +240,7 @@ class BaseParallelSSHClient(object):
                 ex = Timeout()
             if raise_error:
                 raise ex
-            return HostOutput(host=host,exception=ex, alias=alias)
+            return HostOutput(host=host, exception=ex, alias=alias)
 
     def get_last_output(self, cmds=None):
         """Get output for last commands executed by ``run_command``.

--- a/pssh/clients/base/single.py
+++ b/pssh/clients/base/single.py
@@ -159,7 +159,7 @@ class BaseSSHClient(object):
 
     def __init__(self, host,
                  user=None, password=None, port=None,
-                 pkey=None,
+                 pkey=None, alias=None,
                  num_retries=DEFAULT_RETRIES,
                  retry_delay=RETRY_DELAY,
                  allow_agent=True, timeout=None,

--- a/pssh/clients/base/single.py
+++ b/pssh/clients/base/single.py
@@ -171,6 +171,7 @@ class BaseSSHClient(object):
                  ):
         self._auth_thread_pool = _auth_thread_pool
         self.host = host
+        self.alias = alias
         self.user = user if user else getuser()
         self.password = password
         self.port = port if port else 22
@@ -225,7 +226,7 @@ class BaseSSHClient(object):
     def __exit__(self, *args):
         self.disconnect()
 
-    def open_shell(self, encoding='utf-8', read_timeout=None, alias=None):
+    def open_shell(self, encoding='utf-8', read_timeout=None):
         """Open interactive shell on new channel.
 
         Can be used as context manager - ``with open_shell() as shell``.
@@ -236,7 +237,7 @@ class BaseSSHClient(object):
         :type read_timeout: float
         """
         chan = self.open_session()
-        shell = InteractiveShell(chan, self, encoding=encoding, read_timeout=read_timeout, alias=alias)
+        shell = InteractiveShell(chan, self, encoding=encoding, read_timeout=read_timeout)
         return shell
 
     def _shell(self, channel):

--- a/pssh/clients/base/single.py
+++ b/pssh/clients/base/single.py
@@ -225,7 +225,7 @@ class BaseSSHClient(object):
     def __exit__(self, *args):
         self.disconnect()
 
-    def open_shell(self, encoding='utf-8', read_timeout=None):
+    def open_shell(self, encoding='utf-8', read_timeout=None, alias=None):
         """Open interactive shell on new channel.
 
         Can be used as context manager - ``with open_shell() as shell``.
@@ -236,7 +236,7 @@ class BaseSSHClient(object):
         :type read_timeout: float
         """
         chan = self.open_session()
-        shell = InteractiveShell(chan, self, encoding=encoding, read_timeout=read_timeout)
+        shell = InteractiveShell(chan, self, encoding=encoding, read_timeout=read_timeout, alias=alias)
         return shell
 
     def _shell(self, channel):

--- a/pssh/clients/base/single.py
+++ b/pssh/clients/base/single.py
@@ -410,7 +410,7 @@ class BaseSSHClient(object):
             stdout=BufferData(rw_buffer=_stdout_buffer, reader=_stdout_reader),
             stderr=BufferData(rw_buffer=_stderr_buffer, reader=_stderr_reader))
         host_out = HostOutput(
-            host=self.host, channel=channel, stdin=Stdin(channel, self),
+            host=self.host, alias=self.alias, channel=channel, stdin=Stdin(channel, self),
             client=self, encoding=encoding, read_timeout=read_timeout,
             buffers=_buffers,
         )

--- a/pssh/clients/native/parallel.py
+++ b/pssh/clients/native/parallel.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 class ParallelSSHClient(BaseParallelSSHClient):
     """ssh2-python based parallel client."""
 
-    def __init__(self, hosts, user=None, password=None, port=22, pkey=None,
+    def __init__(self, hosts, user=None, password=None, port=22, alias=None, pkey=None,
                  num_retries=DEFAULT_RETRIES, timeout=None, pool_size=100,
                  allow_agent=True, host_config=None, retry_delay=RETRY_DELAY,
                  proxy_host=None, proxy_port=None,
@@ -46,6 +46,8 @@ class ParallelSSHClient(BaseParallelSSHClient):
         :param password: (Optional) Password to use for login. Defaults to
           no password
         :type password: str
+        :param alias: Use an alias for this host.
+        :type alias: str or int
         :param port: (Optional) Port number to use for SSH connection. Defaults
           to 22.
         :type port: int
@@ -121,7 +123,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
         """
         BaseParallelSSHClient.__init__(
             self, hosts, user=user, password=password, port=port, pkey=pkey,
-            allow_agent=allow_agent, num_retries=num_retries,
+            alias=alias, allow_agent=allow_agent, num_retries=num_retries,
             timeout=timeout, pool_size=pool_size,
             host_config=host_config, retry_delay=retry_delay,
             identity_auth=identity_auth,
@@ -231,6 +233,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
         _client = SSHClient(
             host, user=cfg.user or self.user, password=cfg.password or self.password, port=cfg.port or self.port,
             pkey=_pkey_data, num_retries=cfg.num_retries or self.num_retries,
+            alias=cfg.alias or self.alias,
             timeout=cfg.timeout or self.timeout,
             allow_agent=cfg.allow_agent or self.allow_agent, retry_delay=cfg.retry_delay or self.retry_delay,
             proxy_host=cfg.proxy_host or self.proxy_host,

--- a/pssh/clients/native/parallel.py
+++ b/pssh/clients/native/parallel.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 class ParallelSSHClient(BaseParallelSSHClient):
     """ssh2-python based parallel client."""
 
-    def __init__(self, hosts, user=None, password=None, port=22, alias=None, pkey=None,
+    def __init__(self, hosts, user=None, password=None, port=22, pkey=None,
                  num_retries=DEFAULT_RETRIES, timeout=None, pool_size=100,
                  allow_agent=True, host_config=None, retry_delay=RETRY_DELAY,
                  proxy_host=None, proxy_port=None,
@@ -46,8 +46,6 @@ class ParallelSSHClient(BaseParallelSSHClient):
         :param password: (Optional) Password to use for login. Defaults to
           no password
         :type password: str
-        :param alias: Use an alias for this host.
-        :type alias: str or int
         :param port: (Optional) Port number to use for SSH connection. Defaults
           to 22.
         :type port: int
@@ -117,15 +115,13 @@ class ParallelSSHClient(BaseParallelSSHClient):
           for the host(s) or raise NoIPv6AddressFoundError otherwise. Note this will
           disable connecting to an IPv4 address if an IP address is provided instead.
         :type ipv6_only: bool
-        :param alias: Use an alias for this host.
-        :type alias: str or int
 
         :raises: :py:class:`pssh.exceptions.PKeyFileError` on errors finding
           provided private key.
         """
         BaseParallelSSHClient.__init__(
             self, hosts, user=user, password=password, port=port, pkey=pkey,
-            alias=alias, allow_agent=allow_agent, num_retries=num_retries,
+            allow_agent=allow_agent, num_retries=num_retries,
             timeout=timeout, pool_size=pool_size,
             host_config=host_config, retry_delay=retry_delay,
             identity_auth=identity_auth,
@@ -142,7 +138,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
 
     def run_command(self, command, sudo=False, user=None, stop_on_errors=True,
                     use_pty=False, host_args=None, shell=None,
-                    encoding='utf-8', read_timeout=None, alias=None,
+                    encoding='utf-8', read_timeout=None,
                     ):
         """Run command on all hosts in parallel, honoring self.pool_size,
         and return output.
@@ -187,8 +183,6 @@ class ParallelSSHClient(BaseParallelSSHClient):
         :param encoding: Encoding to use for command string and output. Must be valid
           `Python codec <https://docs.python.org/library/codecs.html>`_
         :type encoding: str
-        :param alias: Use an alias for this host.
-        :type alias: str or int
         :param read_timeout: (Optional) Timeout in seconds for reading from stdout
           or stderr. Reading from stdout/stderr will
           raise :py:class:`pssh.exceptions.Timeout`
@@ -219,7 +213,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
             self, command, stop_on_errors=stop_on_errors, host_args=host_args,
             user=user, shell=shell, sudo=sudo,
             encoding=encoding, use_pty=use_pty,
-            read_timeout=read_timeout, alias=alias,
+            read_timeout=read_timeout,
         )
 
     def __del__(self):
@@ -237,7 +231,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
         _client = SSHClient(
             host, user=cfg.user or self.user, password=cfg.password or self.password, port=cfg.port or self.port,
             pkey=_pkey_data, num_retries=cfg.num_retries or self.num_retries,
-            alias=cfg.alias or self.alias,
+            alias=cfg.alias,
             timeout=cfg.timeout or self.timeout,
             allow_agent=cfg.allow_agent or self.allow_agent, retry_delay=cfg.retry_delay or self.retry_delay,
             proxy_host=cfg.proxy_host or self.proxy_host,

--- a/pssh/clients/native/parallel.py
+++ b/pssh/clients/native/parallel.py
@@ -140,7 +140,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
 
     def run_command(self, command, sudo=False, user=None, stop_on_errors=True,
                     use_pty=False, host_args=None, shell=None,
-                    encoding='utf-8', read_timeout=None,
+                    encoding='utf-8', read_timeout=None, alias=None,
                     ):
         """Run command on all hosts in parallel, honoring self.pool_size,
         and return output.
@@ -215,7 +215,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
             self, command, stop_on_errors=stop_on_errors, host_args=host_args,
             user=user, shell=shell, sudo=sudo,
             encoding=encoding, use_pty=use_pty,
-            read_timeout=read_timeout,
+            read_timeout=read_timeout, alias=alias,
         )
 
     def __del__(self):

--- a/pssh/clients/native/parallel.py
+++ b/pssh/clients/native/parallel.py
@@ -117,6 +117,8 @@ class ParallelSSHClient(BaseParallelSSHClient):
           for the host(s) or raise NoIPv6AddressFoundError otherwise. Note this will
           disable connecting to an IPv4 address if an IP address is provided instead.
         :type ipv6_only: bool
+        :param alias: Use an alias for this host.
+        :type alias: str or int
 
         :raises: :py:class:`pssh.exceptions.PKeyFileError` on errors finding
           provided private key.
@@ -185,6 +187,8 @@ class ParallelSSHClient(BaseParallelSSHClient):
         :param encoding: Encoding to use for command string and output. Must be valid
           `Python codec <https://docs.python.org/library/codecs.html>`_
         :type encoding: str
+        :param alias: Use an alias for this host.
+        :type alias: str or int
         :param read_timeout: (Optional) Timeout in seconds for reading from stdout
           or stderr. Reading from stdout/stderr will
           raise :py:class:`pssh.exceptions.Timeout`

--- a/pssh/clients/native/single.py
+++ b/pssh/clients/native/single.py
@@ -117,6 +117,7 @@ class SSHClient(BaseSSHClient):
         self.keepalive_seconds = keepalive_seconds
         self._keepalive_greenlet = None
         self._proxy_client = None
+        self.alias = alias
         self.host = host
         self.port = port if port is not None else 22
         if proxy_host is not None:

--- a/pssh/clients/native/single.py
+++ b/pssh/clients/native/single.py
@@ -71,7 +71,7 @@ class SSHClient(BaseSSHClient):
         :param password: Password to use for password authentication.
         :type password: str
         :param alias: Use an alias for this host.
-        :type alias: str or int
+        :type alias: str
         :param port: SSH port to connect to. Defaults to SSH default (22)
         :type port: int
         :param pkey: Private key file path to use for authentication. Path must

--- a/pssh/clients/native/single.py
+++ b/pssh/clients/native/single.py
@@ -50,7 +50,7 @@ class SSHClient(BaseSSHClient):
 
     def __init__(self, host,
                  user=None, password=None, port=None,
-                 pkey=None,
+                 pkey=None, alias=None,
                  num_retries=DEFAULT_RETRIES,
                  retry_delay=RETRY_DELAY,
                  allow_agent=True, timeout=None,
@@ -70,6 +70,8 @@ class SSHClient(BaseSSHClient):
         :type user: str
         :param password: Password to use for password authentication.
         :type password: str
+        :param alias: Use an alias for this host.
+        :type alias: str or int
         :param port: SSH port to connect to. Defaults to SSH default (22)
         :type port: int
         :param pkey: Private key file path to use for authentication. Path must
@@ -133,7 +135,7 @@ class SSHClient(BaseSSHClient):
             proxy_host = '127.0.0.1'
         self._chan_lock = RLock()
         super(SSHClient, self).__init__(
-            host, user=user, password=password, port=port, pkey=pkey,
+            host, user=user, password=password, alias=alias, port=port, pkey=pkey,
             num_retries=num_retries, retry_delay=retry_delay,
             allow_agent=allow_agent, _auth_thread_pool=_auth_thread_pool,
             timeout=timeout,
@@ -146,7 +148,7 @@ class SSHClient(BaseSSHClient):
         return self._eagain(channel.shell)
 
     def _connect_proxy(self, proxy_host, proxy_port, proxy_pkey,
-                       user=None, password=None,
+                       user=None, password=None, alias=None,
                        num_retries=DEFAULT_RETRIES,
                        retry_delay=RETRY_DELAY,
                        allow_agent=True, timeout=None,
@@ -156,7 +158,7 @@ class SSHClient(BaseSSHClient):
         assert isinstance(self.port, int)
         try:
             self._proxy_client = SSHClient(
-                proxy_host, port=proxy_port, pkey=proxy_pkey,
+                proxy_host, port=proxy_port, pkey=proxy_pkey, alias=alias,
                 num_retries=num_retries, user=user, password=password,
                 retry_delay=retry_delay, allow_agent=allow_agent,
                 timeout=timeout, forward_ssh_agent=forward_ssh_agent,

--- a/pssh/clients/ssh/parallel.py
+++ b/pssh/clients/ssh/parallel.py
@@ -30,7 +30,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
     """ssh-python based parallel client."""
 
     def __init__(self, hosts, user=None, password=None, port=22, pkey=None,
-                 cert_file=None,
+                 cert_file=None, alias=None,
                  num_retries=DEFAULT_RETRIES, timeout=None, pool_size=100,
                  allow_agent=True, host_config=None, retry_delay=RETRY_DELAY,
                  forward_ssh_agent=False,
@@ -49,6 +49,8 @@ class ParallelSSHClient(BaseParallelSSHClient):
         :param password: (Optional) Password to use for login. Defaults to
           no password
         :type password: str
+        :param alias: Use an alias for this host.
+        :type alias: str or int
         :param port: (Optional) Port number to use for SSH connection. Defaults
           to 22.
         :type port: int
@@ -119,7 +121,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
           provided private key.
         """
         BaseParallelSSHClient.__init__(
-            self, hosts, user=user, password=password, port=port, pkey=pkey,
+            self, hosts, user=user, password=password, port=port, pkey=pkey, alias=alias,
             allow_agent=allow_agent, num_retries=num_retries,
             timeout=timeout, pool_size=pool_size,
             host_config=host_config, retry_delay=retry_delay,
@@ -217,6 +219,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
         _client = SSHClient(
             host, user=cfg.user or self.user, password=cfg.password or self.password, port=cfg.port or self.port,
             pkey=_pkey_data, num_retries=cfg.num_retries or self.num_retries,
+            alias=cfg.alias or self.alias,
             timeout=cfg.timeout or self.timeout,
             allow_agent=cfg.allow_agent or self.allow_agent, retry_delay=cfg.retry_delay or self.retry_delay,
             _auth_thread_pool=cfg.auth_thread_pool or self._auth_thread_pool,

--- a/pssh/clients/ssh/parallel.py
+++ b/pssh/clients/ssh/parallel.py
@@ -138,7 +138,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
 
     def run_command(self, command, sudo=False, user=None, stop_on_errors=True,
                     use_pty=False, host_args=None, shell=None,
-                    encoding='utf-8', read_timeout=None,
+                    encoding='utf-8', read_timeout=None, alias=None,
                     ):
         """Run command on all hosts in parallel, honoring self.pool_size,
         and return output.
@@ -163,6 +163,8 @@ class ParallelSSHClient(BaseParallelSSHClient):
         :param user: (Optional) User to run command as. Requires sudo access
           for that user from the logged in user account.
         :type user: str
+        :param alias: Use an alias for this host.
+        :type alias: str or int
         :param stop_on_errors: (Optional) Raise exception on errors running
           command. Defaults to True. With stop_on_errors set to False,
           exceptions are instead added to output of `run_command`. See example
@@ -212,7 +214,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
             self, command, stop_on_errors=stop_on_errors, host_args=host_args,
             user=user, shell=shell, sudo=sudo,
             encoding=encoding, use_pty=use_pty,
-            read_timeout=read_timeout,
+            read_timeout=read_timeout, alias=alias,
         )
 
     def _make_ssh_client(self, host, cfg, _pkey_data):

--- a/pssh/clients/ssh/parallel.py
+++ b/pssh/clients/ssh/parallel.py
@@ -30,7 +30,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
     """ssh-python based parallel client."""
 
     def __init__(self, hosts, user=None, password=None, port=22, pkey=None,
-                 cert_file=None, alias=None,
+                 cert_file=None,
                  num_retries=DEFAULT_RETRIES, timeout=None, pool_size=100,
                  allow_agent=True, host_config=None, retry_delay=RETRY_DELAY,
                  forward_ssh_agent=False,
@@ -49,8 +49,6 @@ class ParallelSSHClient(BaseParallelSSHClient):
         :param password: (Optional) Password to use for login. Defaults to
           no password
         :type password: str
-        :param alias: Use an alias for this host.
-        :type alias: str or int
         :param port: (Optional) Port number to use for SSH connection. Defaults
           to 22.
         :type port: int
@@ -121,7 +119,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
           provided private key.
         """
         BaseParallelSSHClient.__init__(
-            self, hosts, user=user, password=password, port=port, pkey=pkey, alias=alias,
+            self, hosts, user=user, password=password, port=port, pkey=pkey,
             allow_agent=allow_agent, num_retries=num_retries,
             timeout=timeout, pool_size=pool_size,
             host_config=host_config, retry_delay=retry_delay,
@@ -138,7 +136,7 @@ class ParallelSSHClient(BaseParallelSSHClient):
 
     def run_command(self, command, sudo=False, user=None, stop_on_errors=True,
                     use_pty=False, host_args=None, shell=None,
-                    encoding='utf-8', read_timeout=None, alias=None,
+                    encoding='utf-8', read_timeout=None,
                     ):
         """Run command on all hosts in parallel, honoring self.pool_size,
         and return output.
@@ -163,8 +161,6 @@ class ParallelSSHClient(BaseParallelSSHClient):
         :param user: (Optional) User to run command as. Requires sudo access
           for that user from the logged in user account.
         :type user: str
-        :param alias: Use an alias for this host.
-        :type alias: str or int
         :param stop_on_errors: (Optional) Raise exception on errors running
           command. Defaults to True. With stop_on_errors set to False,
           exceptions are instead added to output of `run_command`. See example
@@ -214,14 +210,14 @@ class ParallelSSHClient(BaseParallelSSHClient):
             self, command, stop_on_errors=stop_on_errors, host_args=host_args,
             user=user, shell=shell, sudo=sudo,
             encoding=encoding, use_pty=use_pty,
-            read_timeout=read_timeout, alias=alias,
+            read_timeout=read_timeout,
         )
 
     def _make_ssh_client(self, host, cfg, _pkey_data):
         _client = SSHClient(
             host, user=cfg.user or self.user, password=cfg.password or self.password, port=cfg.port or self.port,
             pkey=_pkey_data, num_retries=cfg.num_retries or self.num_retries,
-            alias=cfg.alias or self.alias,
+            alias=cfg.alias,
             timeout=cfg.timeout or self.timeout,
             allow_agent=cfg.allow_agent or self.allow_agent, retry_delay=cfg.retry_delay or self.retry_delay,
             _auth_thread_pool=cfg.auth_thread_pool or self._auth_thread_pool,

--- a/pssh/clients/ssh/single.py
+++ b/pssh/clients/ssh/single.py
@@ -40,7 +40,7 @@ class SSHClient(BaseSSHClient):
 
     def __init__(self, host,
                  user=None, password=None, port=None,
-                 pkey=None,
+                 pkey=None, alias=None,
                  cert_file=None,
                  num_retries=DEFAULT_RETRIES,
                  retry_delay=RETRY_DELAY,
@@ -60,6 +60,8 @@ class SSHClient(BaseSSHClient):
         :type password: str
         :param port: SSH port to connect to. Defaults to SSH default (22)
         :type port: int
+        :param alias: Use an alias for this host.
+        :type alias: str or int
         :param pkey: Private key file path to use for authentication. Path must
           be either absolute path or relative to user home directory
           like ``~/<path>``.
@@ -114,7 +116,7 @@ class SSHClient(BaseSSHClient):
         self.gssapi_client_identity = gssapi_client_identity
         self.gssapi_delegate_credentials = gssapi_delegate_credentials
         super(SSHClient, self).__init__(
-            host, user=user, password=password, port=port, pkey=pkey,
+            host, user=user, password=password, port=port, pkey=pkey, alias=alias,
             num_retries=num_retries, retry_delay=retry_delay,
             allow_agent=allow_agent,
             _auth_thread_pool=_auth_thread_pool,

--- a/pssh/clients/ssh/single.py
+++ b/pssh/clients/ssh/single.py
@@ -61,7 +61,7 @@ class SSHClient(BaseSSHClient):
         :param port: SSH port to connect to. Defaults to SSH default (22)
         :type port: int
         :param alias: Use an alias for this host.
-        :type alias: str or int
+        :type alias: str
         :param pkey: Private key file path to use for authentication. Path must
           be either absolute path or relative to user home directory
           like ``~/<path>``.

--- a/pssh/config.py
+++ b/pssh/config.py
@@ -133,7 +133,7 @@ class HostConfig(object):
             raise ValueError("Port %s is not an integer" % (self.port,))
         if self.password is not None and not isinstance(self.password, str):
             raise ValueError("Password %s is not a string" % (self.password,))
-        if self.alias is not None and not isinstance(self.alias, (str, int)):
+        if self.alias is not None and not isinstance(self.alias, str):
             raise ValueError("Alias %s is not a string" % (self.alias,))
         if self.private_key is not None and not (
                 isinstance(self.private_key, str) or isinstance(self.private_key, bytes)

--- a/pssh/config.py
+++ b/pssh/config.py
@@ -134,7 +134,7 @@ class HostConfig(object):
         if self.password is not None and not isinstance(self.password, str):
             raise ValueError("Password %s is not a string" % (self.password,))
         if self.alias is not None and not isinstance(self.alias, (str, int)):
-            raise ValueError("Alias %s is not a string or integer" % (self.alias,))
+            raise ValueError("Alias %s is not a string" % (self.alias,))
         if self.private_key is not None and not (
                 isinstance(self.private_key, str) or isinstance(self.private_key, bytes)
         ):

--- a/pssh/config.py
+++ b/pssh/config.py
@@ -25,7 +25,7 @@ class HostConfig(object):
     Used to hold individual configuration for each host in ParallelSSHClient host list.
     """
     __slots__ = ('user', 'port', 'password', 'private_key', 'allow_agent',
-                 'num_retries', 'retry_delay', 'timeout', 'identity_auth',
+                 'alias', 'num_retries', 'retry_delay', 'timeout', 'identity_auth',
                  'proxy_host', 'proxy_port', 'proxy_user', 'proxy_password', 'proxy_pkey',
                  'keepalive_seconds', 'ipv6_only', 'cert_file', 'auth_thread_pool', 'gssapi_auth',
                  'gssapi_server_identity', 'gssapi_client_identity', 'gssapi_delegate_credentials',
@@ -33,7 +33,7 @@ class HostConfig(object):
                  )
 
     def __init__(self, user=None, port=None, password=None, private_key=None,
-                 allow_agent=None, num_retries=None, retry_delay=None, timeout=None,
+                 allow_agent=None, alias=None, num_retries=None, retry_delay=None, timeout=None,
                  identity_auth=None,
                  proxy_host=None, proxy_port=None, proxy_user=None, proxy_password=None,
                  proxy_pkey=None,
@@ -58,6 +58,8 @@ class HostConfig(object):
         :type private_key: str
         :param allow_agent: Enable/disable SSH agent authentication.
         :type allow_agent: bool
+        :param alias: Use an alias for this host.
+        :type alias: str or int
         :param num_retries: Number of retry attempts before giving up on connection
           and SSH operations.
         :type num_retries: int
@@ -130,6 +132,8 @@ class HostConfig(object):
             raise ValueError("Port %s is not an integer" % (self.port,))
         if self.password is not None and not isinstance(self.password, str):
             raise ValueError("Password %s is not a string" % (self.password,))
+        if self.alias is not None and not isinstance(self.alias, (str, int)):
+            raise ValueError("Alias %s is not a string or integer" % (self.alias,))
         if self.private_key is not None and not (
                 isinstance(self.private_key, str) or isinstance(self.private_key, bytes)
         ):

--- a/pssh/config.py
+++ b/pssh/config.py
@@ -105,6 +105,7 @@ class HostConfig(object):
         self.password = password
         self.private_key = private_key
         self.allow_agent = allow_agent
+        self.alias = alias
         self.num_retries = num_retries
         self.timeout = timeout
         self.retry_delay = retry_delay

--- a/pssh/output.py
+++ b/pssh/output.py
@@ -120,12 +120,13 @@ class HostOutput(object):
 
     def __repr__(self):
         return "\thost={host}{linesep}" \
+            "\talias={alias}{linesep}" \
             "\texit_code={exit_code}{linesep}" \
             "\tchannel={channel}{linesep}" \
             "\texception={exception}{linesep}" \
             "\tencoding={encoding}{linesep}" \
             "\tread_timeout={read_timeout}".format(
-                host=self.host, channel=self.channel,
+                host=self.host, alias=self.alias, channel=self.channel,
                 exception=self.exception, linesep=linesep,
                 exit_code=self.exit_code, encoding=self.encoding, read_timeout=self.read_timeout,
             )

--- a/pssh/output.py
+++ b/pssh/output.py
@@ -55,13 +55,13 @@ class HostOutput(object):
     """Host output"""
 
     __slots__ = ('host', 'channel', 'stdin',
-                 'client', 'exception', 'encoding', 'read_timeout',
-                 'buffers', 'alias',
+                 'client', 'alias', 'exception',
+                 'encoding', 'read_timeout', 'buffers',
                  )
 
     def __init__(self, host, channel, stdin,
-                 client, exception=None, encoding='utf-8', read_timeout=None,
-                 buffers=None, alias):
+                 client, alias, exception=None, encoding='utf-8', read_timeout=None,
+                 buffers=None):
         """
         :param host: Host name output is for
         :type host: str
@@ -71,24 +71,24 @@ class HostOutput(object):
         :type stdin: :py:func:`file`-like object
         :param client: `SSHClient` output is coming from.
         :type client: :py:class:`pssh.clients.base.single.BaseSSHClient`
+        :param alias: Host alias.
+        :type alias: str or int
         :param exception: Exception from host if any
         :type exception: :py:class:`Exception` or ``None``
         :param read_timeout: Timeout in seconds for reading from buffers.
         :type read_timeout: float
         :param buffers: Host buffer data.
         :type buffers: :py:class:`HostOutputBuffers`
-        :param alias: Host alias.
-        :type alias: str or int
         """
         self.host = host
         self.channel = channel
         self.stdin = stdin
         self.client = client
+        self.alias = alias
         self.exception = exception
         self.encoding = encoding
         self.read_timeout = read_timeout
         self.buffers = buffers
-        self.alias = alias
 
     @property
     def stdout(self):

--- a/pssh/output.py
+++ b/pssh/output.py
@@ -56,12 +56,12 @@ class HostOutput(object):
 
     __slots__ = ('host', 'channel', 'stdin',
                  'client', 'exception', 'encoding', 'read_timeout',
-                 'buffers',
+                 'buffers', 'alias',
                  )
 
     def __init__(self, host, channel, stdin,
                  client, exception=None, encoding='utf-8', read_timeout=None,
-                 buffers=None):
+                 buffers=None, alias):
         """
         :param host: Host name output is for
         :type host: str
@@ -77,6 +77,8 @@ class HostOutput(object):
         :type read_timeout: float
         :param buffers: Host buffer data.
         :type buffers: :py:class:`HostOutputBuffers`
+        :param alias: Host alias.
+        :type alias: str or int
         """
         self.host = host
         self.channel = channel
@@ -86,6 +88,7 @@ class HostOutput(object):
         self.encoding = encoding
         self.read_timeout = read_timeout
         self.buffers = buffers
+        self.alias = alias
 
     @property
     def stdout(self):

--- a/pssh/output.py
+++ b/pssh/output.py
@@ -72,7 +72,7 @@ class HostOutput(object):
         :param client: `SSHClient` output is coming from.
         :type client: :py:class:`pssh.clients.base.single.BaseSSHClient`
         :param alias: Host alias.
-        :type alias: str or int
+        :type alias: str
         :param exception: Exception from host if any
         :type exception: :py:class:`Exception` or ``None``
         :param read_timeout: Timeout in seconds for reading from buffers.

--- a/pssh/output.py
+++ b/pssh/output.py
@@ -60,7 +60,7 @@ class HostOutput(object):
                  )
 
     def __init__(self, host, channel, stdin,
-                 client, alias, exception=None, encoding='utf-8', read_timeout=None,
+                 client, alias=None, exception=None, encoding='utf-8', read_timeout=None,
                  buffers=None):
         """
         :param host: Host name output is for

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -945,6 +945,14 @@ class ParallelSSHClientTest(unittest.TestCase):
                                    host_config=host_config,
                                    num_retries=1)
         output = client.run_command(self.cmd, stop_on_errors=False)
+        
+        # this needs to happen before client.join
+        client_aliases = [alias for alias in [client.alias for client in [client._host_clients[x] for x in client._host_clients]]]
+        self.assertTrue(client._host_clients[0, hosts[0][0]].alias in aliases,
+                        msg=f"Alias didn't pass through: {client._host_clients[0, hosts[0][0]].alias} did not contain any of {aliases}")
+        self.assertTrue(len(set(client_aliases)) == len(aliases),
+                        msg=f"Alias passthrough problem: client_aliases contain duplicate values. Expected {aliases} but got {client_aliases}")
+        
         client.join(output)
         self.assertEqual(len(hosts), len(output))
         try:
@@ -956,11 +964,6 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].user, self.user)
         self.assertEqual(client._host_clients[0, hosts[0][0]].password, password)
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
-        self.assertTrue(client._host_clients[0, hosts[0][0]].alias in aliases,
-                       msg=f"Alias didn't pass through: {client._host_clients[0, hosts[0][0]].alias} did not contain any of {aliases}")
-        client_aliases = [alias for alias in [client.alias for client in [client._host_clients[x] for x in client._host_clients]]]
-        self.assertTrue(len(set(client_aliases)) == len(aliases),
-                           msg=f"Alias passthrough problem: {client_aliases} contain duplicate values. Expected {aliases}")
         for server in servers:
             server.stop()
 

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -957,7 +957,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].password, password)
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
         for idx, alias_ in enumerate(alias):
-            self.assertEqual(output[idx].alias, alias_)
+            self.assertEqual(client._host_clients[idx, hosts[0][0]].alias, alias_)
         for server in servers:
             server.stop()
 

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -930,7 +930,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         servers = []
         password = 'overriden_pass'
         fake_key = 'FAKE KEY'
-        aliases = [f"alias for host {host_i}" for host_i in hosts]
+        aliases = [f"alias for host {host_i}" for host_i, _ in enumerate(hosts)]
         for host_i, (host, port) in enumerate(hosts):
             server = OpenSSHServer(listen_ip=host, port=port)
             server.start_server()

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -959,7 +959,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertTrue(client._host_clients[0, hosts[0][0]].alias in aliases,
                        msg=f"Alias didn't pass through: {client._host_clients[0, hosts[0][0]].alias} did not contain any of {aliases}")
         client_aliases = [client._host_clients[idx, hosts[0][0]].alias for idx in range(len(output))]
-        self.assertTrue(len(set(client_aliases)), len(aliases),
+        self.assertTrue(len(set(client_aliases)) == len(aliases),
                            msg=f"Alias passthrough problem: {client_aliases} contain duplicate values. Expected {aliases}")
         for server in servers:
             server.stop()

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -958,7 +958,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
         self.assertTrue(client._host_clients[0, hosts[0][0]].alias in aliases,
                        msg=f"Alias didn't pass through: {client._host_clients[0, hosts[0][0]].alias} did not contain any of {aliases}")
-        client_aliases = [client._host_clients[idx, hosts[idx][0]].alias for idx in range(len(output))]
+        client_aliases = [alias for alias in [client.alias for client in [client._host_clients[x] for x in client._host_clients]]])
         self.assertTrue(len(set(client_aliases)) == len(aliases),
                            msg=f"Alias passthrough problem: {client_aliases} contain duplicate values. Expected {aliases}")
         for server in servers:

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -956,8 +956,8 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].user, self.user)
         self.assertEqual(client._host_clients[0, hosts[0][0]].password, password)
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
-        for idx, alias_ in enumerate(alias):
-            self.assertTrue(alias_ in output[idx])
+        for alias_ in alias:
+            self.assertTrue(alias_ in output)
         for server in servers:
             server.stop()
 

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -958,7 +958,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
         self.assertTrue(client._host_clients[0, hosts[0][0]].alias in aliases,
                        msg=f"Alias didn't pass through: {client._host_clients[0, hosts[0][0]].alias} did not contain any of {aliases}")
-        client_aliases = [client._host_clients[idx, hosts[0][0]].alias for idx in range(len(output))]
+        client_aliases = [client._host_clients[idx, hosts[idx][0]].alias for idx in range(len(output))]
         self.assertTrue(len(set(client_aliases)) == len(aliases),
                            msg=f"Alias passthrough problem: {client_aliases} contain duplicate values. Expected {aliases}")
         for server in servers:

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -958,6 +958,9 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
         self.assertTrue(client._host_clients[0, hosts[0][0]].alias in aliases,
                        msg=f"Alias didn't pass through: {client._host_clients[0, hosts[0][0]].alias} did not contain any of {aliases}")
+        client_aliases = [client._host_clients[idx, hosts[0][0]].alias for idx in range(len(output))]
+        self.assertTrue(len(set(client_aliases), len(aliases),
+                           msg=f"Alias passthrough problem: {client_aliases} contain duplicate values. Expected {aliases}")
         for server in servers:
             server.stop()
 

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -957,7 +957,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].user, self.user)
         self.assertEqual(client._host_clients[0, hosts[0][0]].password, password)
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
-        self.assertEqual(set(aliases), set(output.alias))
+        self.assertEqual(set(aliases), set([client.alias for client in output]))
 
         for server in servers:
             server.stop()

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -958,14 +958,8 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].password, password)
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
         
-        client_aliases = [alias for alias in [client.alias for client in [client._host_clients[x] for x in client._host_clients]]]
-        self.assertTrue(client._host_clients[0, hosts[0][0]].alias in aliases,
-                        msg=f"Alias didn't pass through: {client._host_clients[0, hosts[0][0]].alias} did not contain any of {aliases}")
-       
-        ### this works but requires more than one successful connection. for example if n hosts was 3, not 2.
-        # self.assertEqual(len(set(client_aliases)), len(aliases),
-        #                msg=f"Alias passthrough problem: client_aliases contain duplicate values. Expected {aliases} but got {client_aliases}")
-        ###
+        ### TODO: add test for alias passthrough
+
         for server in servers:
             server.stop()
 

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -946,13 +946,6 @@ class ParallelSSHClientTest(unittest.TestCase):
                                    num_retries=1)
         output = client.run_command(self.cmd, stop_on_errors=False)
         
-        # this needs to happen before client.join
-        client_aliases = [alias for alias in [client.alias for client in [client._host_clients[x] for x in client._host_clients]]]
-        self.assertTrue(client._host_clients[0, hosts[0][0]].alias in aliases,
-                        msg=f"Alias didn't pass through: {client._host_clients[0, hosts[0][0]].alias} did not contain any of {aliases}")
-        self.assertTrue(len(set(client_aliases)) == len(aliases),
-                        msg=f"Alias passthrough problem: client_aliases contain duplicate values. Expected {aliases} but got {client_aliases}")
-        
         client.join(output)
         self.assertEqual(len(hosts), len(output))
         try:
@@ -964,6 +957,15 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].user, self.user)
         self.assertEqual(client._host_clients[0, hosts[0][0]].password, password)
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
+        
+        client_aliases = [alias for alias in [client.alias for client in [client._host_clients[x] for x in client._host_clients]]]
+        self.assertTrue(client._host_clients[0, hosts[0][0]].alias in aliases,
+                        msg=f"Alias didn't pass through: {client._host_clients[0, hosts[0][0]].alias} did not contain any of {aliases}")
+       
+        ### this works but requires more than one successful connection. for example if n hosts was 3, not 2.
+        # self.assertEqual(len(set(client_aliases)), len(aliases),
+        #                msg=f"Alias passthrough problem: client_aliases contain duplicate values. Expected {aliases} but got {client_aliases}")
+        ###
         for server in servers:
             server.stop()
 

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -959,7 +959,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertTrue(client._host_clients[0, hosts[0][0]].alias in aliases,
                        msg=f"Alias didn't pass through: {client._host_clients[0, hosts[0][0]].alias} did not contain any of {aliases}")
         client_aliases = [client._host_clients[idx, hosts[0][0]].alias for idx in range(len(output))]
-        self.assertTrue(len(set(client_aliases), len(aliases),
+        self.assertTrue(len(set(client_aliases)), len(aliases),
                            msg=f"Alias passthrough problem: {client_aliases} contain duplicate values. Expected {aliases}")
         for server in servers:
             server.stop()

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -958,7 +958,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
         self.assertTrue(client._host_clients[0, hosts[0][0]].alias in aliases,
                        msg=f"Alias didn't pass through: {client._host_clients[0, hosts[0][0]].alias} did not contain any of {aliases}")
-        client_aliases = [alias for alias in [client.alias for client in [client._host_clients[x] for x in client._host_clients]]])
+        client_aliases = [alias for alias in [client.alias for client in [client._host_clients[x] for x in client._host_clients]]]
         self.assertTrue(len(set(client_aliases)) == len(aliases),
                            msg=f"Alias passthrough problem: {client_aliases} contain duplicate values. Expected {aliases}")
         for server in servers:

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -930,6 +930,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         servers = []
         password = 'overriden_pass'
         fake_key = 'FAKE KEY'
+        alias = ["alias " + host for host in hosts]
         for host_i, (host, port) in enumerate(hosts):
             server = OpenSSHServer(listen_ip=host, port=port)
             server.start_server()
@@ -937,6 +938,7 @@ class ParallelSSHClientTest(unittest.TestCase):
             host_config[host_i].user = self.user
             host_config[host_i].password = password
             host_config[host_i].private_key = self.user_key
+            host_config[host_i].alias = alias[host_i]
             servers.append(server)
         host_config[1].private_key = fake_key
         client = ParallelSSHClient([h for h, _ in hosts],
@@ -954,6 +956,8 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].user, self.user)
         self.assertEqual(client._host_clients[0, hosts[0][0]].password, password)
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
+        for idx, alias_ in enumerate(alias):
+            self.assertEqual(client._host_clients[idx, hosts[0][0]].alias, alias_)
         for server in servers:
             server.stop()
 

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -930,7 +930,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         servers = []
         password = 'overriden_pass'
         fake_key = 'FAKE KEY'
-        alias = ["alias " + host for host in hosts]
+        alias = [f"alias {host}" for host in hosts]
         for host_i, (host, port) in enumerate(hosts):
             server = OpenSSHServer(listen_ip=host, port=port)
             server.start_server()

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -957,8 +957,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].password, password)
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
         for idx, alias_ in enumerate(alias):
-            print(client._host_clients[idx, hosts[0][0]])
-            self.assertEqual(client._host_clients[idx, hosts[0][0]].alias, alias_)
+            self.assertTrue(alias_ in output[idx])
         for server in servers:
             server.stop()
 

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -957,8 +957,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].user, self.user)
         self.assertEqual(client._host_clients[0, hosts[0][0]].password, password)
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
-        
-        ### TODO: add test for alias passthrough
+        self.assertEqual(set(aliases), set(output.alias))
 
         for server in servers:
             server.stop()

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -957,6 +957,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].password, password)
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
         for idx, alias_ in enumerate(alias):
+            print(client._host_clients[idx, hosts[0][0]])
             self.assertEqual(client._host_clients[idx, hosts[0][0]].alias, alias_)
         for server in servers:
             server.stop()

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -930,7 +930,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         servers = []
         password = 'overriden_pass'
         fake_key = 'FAKE KEY'
-        alias = [f"alias {host}" for host in hosts]
+        aliases = [f"alias {host}" for host in hosts]
         for host_i, (host, port) in enumerate(hosts):
             server = OpenSSHServer(listen_ip=host, port=port)
             server.start_server()
@@ -938,7 +938,7 @@ class ParallelSSHClientTest(unittest.TestCase):
             host_config[host_i].user = self.user
             host_config[host_i].password = password
             host_config[host_i].private_key = self.user_key
-            host_config[host_i].alias = alias[host_i]
+            host_config[host_i].alias = aliases[host_i]
             servers.append(server)
         host_config[1].private_key = fake_key
         client = ParallelSSHClient([h for h, _ in hosts],
@@ -956,8 +956,8 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].user, self.user)
         self.assertEqual(client._host_clients[0, hosts[0][0]].password, password)
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
-        for alias_ in alias:
-            self.assertTrue(alias_ in output)
+        self.assertTrue(any(aliases) in client._host_clients[0, hosts[0][0]].alias,
+                       msg=f"Alias didn't pass through: {client._host_clients[0, hosts[0][0]].alias} did not contain any of {aliases}")
         for server in servers:
             server.stop()
 

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -956,7 +956,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].user, self.user)
         self.assertEqual(client._host_clients[0, hosts[0][0]].password, password)
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
-        self.assertTrue(any(aliases) in client._host_clients[0, hosts[0][0]].alias,
+        self.assertTrue(client._host_clients[0, hosts[0][0]].alias in aliases,
                        msg=f"Alias didn't pass through: {client._host_clients[0, hosts[0][0]].alias} did not contain any of {aliases}")
         for server in servers:
             server.stop()

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -930,7 +930,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         servers = []
         password = 'overriden_pass'
         fake_key = 'FAKE KEY'
-        aliases = [f"alias {host}" for host in hosts]
+        aliases = [f"alias for host {host_i}" for host_i in hosts]
         for host_i, (host, port) in enumerate(hosts):
             server = OpenSSHServer(listen_ip=host, port=port)
             server.start_server()

--- a/tests/native/test_parallel_client.py
+++ b/tests/native/test_parallel_client.py
@@ -957,7 +957,7 @@ class ParallelSSHClientTest(unittest.TestCase):
         self.assertEqual(client._host_clients[0, hosts[0][0]].password, password)
         self.assertEqual(client._host_clients[0, hosts[0][0]].pkey, open(os.path.abspath(self.user_key), 'rb').read())
         for idx, alias_ in enumerate(alias):
-            self.assertEqual(client._host_clients[idx, hosts[0][0]].alias, alias_)
+            self.assertEqual(output[idx].alias, alias_)
         for server in servers:
             server.stop()
 

--- a/tests/native/test_single_client.py
+++ b/tests/native/test_single_client.py
@@ -182,7 +182,7 @@ class SSH2ClientTest(SSH2TestCase):
         self.assertEqual(expected, output)
         
     def test_alias(self):
-        client = _SSHClient(self.host, port=self.port,
+        client = SSHClient(self.host, port=self.port,
                            num_retries=1, alias='test')
         host_out = client.run_command(self.cmd)
         self.assertEqual(host_out.alias, 'test')

--- a/tests/native/test_single_client.py
+++ b/tests/native/test_single_client.py
@@ -182,8 +182,9 @@ class SSH2ClientTest(SSH2TestCase):
         self.assertEqual(expected, output)
         
     def test_alias(self):
-        client = SSHClient(self.host, port=self.port,
-                           num_retries=1, alias='test')
+        client = SSHClient(self.host, port=self.port, 
+                           pkey=self.user_key, num_retries=1,
+                           alias='test')
         host_out = client.run_command(self.cmd)
         self.assertEqual(host_out.alias, 'test')
 

--- a/tests/native/test_single_client.py
+++ b/tests/native/test_single_client.py
@@ -185,8 +185,6 @@ class SSH2ClientTest(SSH2TestCase):
         client = _SSHClient(self.host, port=self.port,
                            num_retries=1, alias='test')
         host_out = client.run_command(self.cmd)
-        output = list(host_out.stdout)
-        stderr = list(host_out.stderr)
         self.assertEqual(host_out.alias, 'test')
 
     def test_open_session_timeout(self):

--- a/tests/native/test_single_client.py
+++ b/tests/native/test_single_client.py
@@ -180,6 +180,14 @@ class SSH2ClientTest(SSH2TestCase):
         exit_code = host_out.channel.get_exit_status()
         self.assertEqual(host_out.exit_code, 0)
         self.assertEqual(expected, output)
+        
+    def test_alias(self):
+        client = _SSHClient(self.host, port=self.port,
+                           num_retries=1, alias='test')
+        host_out = client.run_command(self.cmd)
+        output = list(host_out.stdout)
+        stderr = list(host_out.stderr)
+        self.assertEqual(host_out.alias, 'test')
 
     def test_open_session_timeout(self):
         client = SSHClient(self.host, port=self.port,

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -26,6 +26,7 @@ class TestHostConfig(unittest.TestCase):
         user = 'user'
         port = 22
         password = 'password'
+        alias = 'alias'
         private_key = 'private key'
         allow_agent = False
         num_retries = 1
@@ -43,7 +44,7 @@ class TestHostConfig(unittest.TestCase):
         gssapi_client_identity = 'some_id'
         gssapi_delegate_credentials = True
         cfg = HostConfig(
-            user=user, port=port, password=password, private_key=private_key,
+            user=user, port=port, password=password, alias=alias, private_key=private_key,
             allow_agent=allow_agent, num_retries=num_retries, retry_delay=retry_delay,
             timeout=timeout, identity_auth=identity_auth, proxy_host=proxy_host,
             ipv6_only=ipv6_only,
@@ -59,6 +60,7 @@ class TestHostConfig(unittest.TestCase):
         self.assertEqual(cfg.user, user)
         self.assertEqual(cfg.port, port)
         self.assertEqual(cfg.password, password)
+        self.assertEqual(cfg.alias, alias)
         self.assertEqual(cfg.private_key, private_key)
         self.assertEqual(cfg.allow_agent, allow_agent)
         self.assertEqual(cfg.num_retries, num_retries)
@@ -79,6 +81,7 @@ class TestHostConfig(unittest.TestCase):
         self.assertRaises(ValueError, HostConfig, user=22)
         self.assertRaises(ValueError, HostConfig, password=22)
         self.assertRaises(ValueError, HostConfig, port='22')
+        self.assertRaises(ValueError, HostConfig, alias=2.2)
         self.assertRaises(ValueError, HostConfig, private_key=1)
         self.assertRaises(ValueError, HostConfig, allow_agent=1)
         self.assertRaises(ValueError, HostConfig, num_retries='')

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -81,7 +81,7 @@ class TestHostConfig(unittest.TestCase):
         self.assertRaises(ValueError, HostConfig, user=22)
         self.assertRaises(ValueError, HostConfig, password=22)
         self.assertRaises(ValueError, HostConfig, port='22')
-        self.assertRaises(ValueError, HostConfig, alias=2.2)
+        self.assertRaises(ValueError, HostConfig, alias=2)
         self.assertRaises(ValueError, HostConfig, private_key=1)
         self.assertRaises(ValueError, HostConfig, allow_agent=1)
         self.assertRaises(ValueError, HostConfig, num_retries='')


### PR DESCRIPTION
this is useful for weird ssh proxies like cyberark PAM. Without this, it is difficult to identify the source of the output, as they all have the same hostname.

As a side effect, this also adds part of the future ~/.ssh/config parsing, which would be nice (as per https://github.com/ParallelSSH/parallel-ssh/issues/103). the openssh config differentiates between host and hostname.

I wrote this code that implements simple ssh config parsing with unix-like pattern matching.
```
    hosts = []
    host_config = []
    i = 0

    with open(Path.expanduser(Path('~/.ssh/config'))) as sshconfig:
        pattern = sys.argv[1].strip('"')
        for line in sshconfig:
            if line.startswith("Host "):
                host = line.split("Host ")[1].split('\n')[0]
                if fnmatch.fnmatch(host,pattern):
                    hostname = next(sshconfig).strip().split("HostName ")[1]
                    user = next(sshconfig).strip().split("User ")[1]
                    hosts.append({})
                    hosts[i]["hostname"] = hostname
                    hosts[i]["user"] = user
                    hosts[i]['alias'] = host
                    i = i+1
        if hosts == []:
            print(f"No hosts matched by pattern {pattern}")
            exit(1)
        for host in hosts:
            host_config.append(HostConfig(user=host['user'], password=os.environ['SSHPASS']))
```