### PR TITLE
fix(native): wait for channel close before returning

### DIFF
--- a/pssh/clients/native/single.py
+++ b/pssh/clients/native/single.py
@@ -418,6 +418,8 @@ class SSHClient(BaseSSHClient):
             self.eagain(channel.wait_eof)
             # Close channel to indicate no more commands will be sent over it
             self.close_channel(channel)
+            # libssh2 exposes an exit status only after the remote close handshake.
+            self.eagain(channel.wait_closed)
 
     def close_channel(self, channel):
         """Close given channel, handling EAGAIN."""

--- a/tests/test_native_single.py
+++ b/tests/test_native_single.py
@@ -1,0 +1,54 @@
+#  This file is part of parallel-ssh.
+#  Copyright (C) 2014-2025 Panos Kittenis.
+#  Copyright (C) 2014-2025 parallel-ssh Contributors.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation, version 2.1.
+
+
+"""Regression tests for the native/libssh2 single-client lifecycle."""
+
+
+import unittest
+
+from pssh.clients.native.single import SSHClient
+from pssh.output import HostOutput
+
+
+class Channel:
+
+    def __init__(self):
+        self.calls = []
+        self.closed = False
+
+    def wait_eof(self):
+        self.calls.append('wait_eof')
+
+    def close(self):
+        self.calls.append('close')
+
+    def wait_closed(self):
+        self.calls.append('wait_closed')
+        self.closed = True
+
+    def eof(self):
+        return self.closed
+
+    def get_exit_status(self):
+        return 0
+
+
+class NativeSingleClientTest(unittest.TestCase):
+
+    def test_wait_finished_waits_for_close_before_exit_status(self):
+        client = object.__new__(SSHClient)
+        client.eagain = lambda func: func()
+        client.close_channel = lambda channel: client.eagain(channel.close)
+        channel = Channel()
+        output = HostOutput('host', channel, None, client=client)
+
+        client.wait_finished(output)
+
+        self.assertEqual(channel.calls, ['wait_eof', 'close', 'wait_closed'])
+        self.assertEqual(output.exit_code, 0)


### PR DESCRIPTION
# Draft: fix native command completion exit-status handshake

Closes #424.

## Summary

- wait for the libssh2 channel close handshake after EOF and local close
- add a regression test covering the command-completion lifecycle before exit
  status is read

## Verification

- `python -m pytest tests/test_native_single.py tests/test_output.py -q`
- `python -m pytest`
- `flake8 pssh/clients/native/single.py tests/test_native_single.py`
- `git diff --check`

## Notes

The reporter observed an exit status of `0` while `channel.eof()` was still
false immediately after `wait_finished()`. libssh2 documents that the exit
status may not be available until the remote channel is closed, so this change
waits for that close handshake before `wait_finished()` returns.

This draft is limited to the local patch bundle reviewed in
`PARALLELSSH_424_AO_GATE_2026-08-04.md`. Any submission still requires a
fresh exact-bundle approval and live revalidation immediately before writing.
